### PR TITLE
[#14] fix(cli): enable clap help feature for proper help menu display

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ pgopr was created by the following authors:
 
 Jesper Pedersen <jesperpedersen.db@gmail.com>
 Cristian Guarino <cristian.guarino.j@gmail.com>
+Nick Boyadjian <nboyadjian95@gmail.com>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ description = "PostgreSQL operator for Kubernetes"
 tokio = { version = "1", features = ["full"] }
 kube = { version = "1.0.0", default-features = true, features = ["client", "derive", "runtime"] }
 k8s-openapi = { version = "0.25.0", default-features = true, features = ["v1_32"] }
-clap = { version = "4.5.37", default-features = false, features = ["std", "cargo"] }
+clap = { version = "4.5.38", default-features = false, features = ["std", "cargo", "help"] }
 clap_complete = { version = "4.5.50" }
 directories = { version = "6.0" }
 figment = { version = "0.10", features = ["env", "toml"] }


### PR DESCRIPTION
## Description:
The help command was not working because it wasn't enabled by default from clap. This PR enables it in the `cargo.toml` file.

## Test plan:
Build pgopr and then run it with the `--help` flag.

<img width="618" alt="image" src="https://github.com/user-attachments/assets/00a7ec69-dfa6-4c65-bd9a-76343aebec57" />

This should be tested for the sub commands as well.
<img width="652" alt="image" src="https://github.com/user-attachments/assets/1f3173a1-ad96-42d6-bf2d-d35578e5c200" />
