### PR TITLE
[#10] k8s 1.32.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ description = "PostgreSQL operator for Kubernetes"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-kube = { version = "0.99.0", default-features = true, features = ["client", "derive", "runtime"] }
-k8s-openapi = { version = "0.24.0", default-features = true, features = ["v1_30"] }
+kube = { version = "1.0.0", default-features = true, features = ["client", "derive", "runtime"] }
+k8s-openapi = { version = "0.25.0", default-features = true, features = ["v1_32"] }
 clap = { version = "4.5.37", default-features = false, features = ["std", "cargo"] }
 clap_complete = { version = "4.5.50" }
 directories = { version = "6.0" }


### PR DESCRIPTION
Updated:

kube to v.1.0
k8s to v1.32

no errors from cargo build
