### PR TITLE
[#13] Shell script for rustfmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@
 [package]
 name = "pgopr"
 version = "0.2.0"
-authors = ["Jesper Pedersen <jesperpedersen.db@gmail.com>", "Cristian Guarino <cristian.guarino.j@gmail.com>"]
-edition = "2021"
+authors = ["Jesper Pedersen <jesperpedersen.db@gmail.com>", "Cristian Guarino <cristian.guarino.j@gmail.com>", "Nick Boyadjian <nboyadjian95@gmail.com>"]
+edition = "2024"
 license = "Eclipse Public License 2.0"
 description = "PostgreSQL operator for Kubernetes"
 

--- a/doc/DEVELOPERS.md
+++ b/doc/DEVELOPERS.md
@@ -210,7 +210,25 @@ Now that we've attempted to use `pgopr`, take a moment to relax. There are a few
 
 1. Since we initialized the database in `/tmp`, the data in this directory might be removed after you go offline, depending on your OS configuration. If you want to make it permanent, choose a different directory.
 
-2. Always use uncrustify to format your code when you make modifications.
+2. Always format your code when you make modifications using the provided rustfmt.sh script.
+
+## Code Formatting
+
+The project includes a simple rustfmt.sh script to ensure consistent code formatting using Rust's built-in formatter (rustfmt). 
+
+### Setting up the rustfmt.sh script
+
+1. Make sure the script is executable:
+   ```sh
+   chmod +x rustfmt.sh
+   ```
+
+2. Running the formatter:
+   ```sh
+   ./rustfmt.sh
+   ```
+
+This script will format all Rust files in the project according to the project's formatting guidelines. Always run this script before committing changes to ensure consistent code style across the codebase.
 
 ## Rust programming
 

--- a/rustfmt.sh
+++ b/rustfmt.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+cargo fmt --all

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -8,10 +8,10 @@
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::CustomResource;
 use kube::{
+    Api, Client, Error,
     api::{DeleteParams, PostParams},
     core::crd::CustomResourceExt,
     runtime::wait::{await_condition, conditions},
-    Api, Client, Error,
 };
 use log::{info, trace};
 use schemars::JsonSchema;
@@ -80,7 +80,10 @@ pub async fn crd_deploy(client: Client) -> Result<CustomResourceDefinition, Erro
 /// Note: It is assumed the deployment exists for simplicity. Otherwise returns an Error.
 pub async fn crd_undeploy(client: Client) -> Result<(), Error> {
     let api: Api<CustomResourceDefinition> = Api::all(client);
-    match api.delete("pgoprs.pgopr.io", &DeleteParams::default()).await {
+    match api
+        .delete("pgoprs.pgopr.io", &DeleteParams::default())
+        .await
+    {
         Ok(_) => {
             info!("Deleted CRD");
         }

--- a/src/finalizer.rs
+++ b/src/finalizer.rs
@@ -7,10 +7,10 @@
  */
 use crate::crd::v1::pgopr;
 use kube::{
-    api::{Patch, PatchParams},
     Api, Client, Error,
+    api::{Patch, PatchParams},
 };
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Adds a finalizer record into a `pgopr` kind of resource. If the finalizer already exists,
 /// this action has no effect.

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,16 +5,16 @@
  *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
  *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
  */
-use clap::{crate_description, crate_name, crate_version, value_parser, Arg, Command};
-use clap_complete::{generate, Generator, Shell};
+use clap::{Arg, Command, crate_description, crate_name, crate_version, value_parser};
+use clap_complete::{Generator, Shell, generate};
 use futures::stream::StreamExt;
 use kube::{
+    Resource, ResourceExt,
     api::Api,
     client::Client,
-    runtime::{controller::Action, watcher, Controller},
-    Resource, ResourceExt,
+    runtime::{Controller, controller::Action, watcher},
 };
-use log::{debug, error, info, LevelFilter};
+use log::{LevelFilter, debug, error, info};
 use log4rs::{
     append::console::{ConsoleAppender, Target},
     config::{Appender, Config, Logger, Root},
@@ -144,8 +144,13 @@ fn cli() -> Command {
 /// - `gen` - The generator to be used
 /// - `cmd` - The command line structure
 ///
-fn generate_completions<G: Generator>(gen: G, cmd: &mut Command) {
-    generate(gen, cmd, cmd.get_name().to_string(), &mut std::io::stdout());
+fn generate_completions<G: Generator>(r#gen: G, cmd: &mut Command) {
+    generate(
+        r#gen,
+        cmd,
+        cmd.get_name().to_string(),
+        &mut std::io::stdout(),
+    );
 }
 
 /// The main method

--- a/src/persistent.rs
+++ b/src/persistent.rs
@@ -12,11 +12,11 @@ use k8s_openapi::{
     },
     apimachinery::pkg::api::resource::Quantity,
 };
-use log::{info, trace};
 use kube::{
-    api::{DeleteParams, ObjectMeta, PostParams},
     Api, Client, Error,
+    api::{DeleteParams, ObjectMeta, PostParams},
 };
+use log::{info, trace};
 use std::collections::BTreeMap;
 use std::fs;
 
@@ -56,10 +56,7 @@ pub async fn persistent_volume_deploy(
 /// - `name` - The name of the persistent volume
 ///
 /// Note: It is assumed the persistence volume exists for simplicity. Otherwise returns an Error.
-pub async fn persistent_volume_undeploy(
-    client: Client,
-    name: &str,
-) -> Result<(), Error> {
+pub async fn persistent_volume_undeploy(client: Client, name: &str) -> Result<(), Error> {
     let api: Api<PersistentVolume> = Api::all(client);
     match api.delete(name, &DeleteParams::default()).await {
         Ok(_) => {
@@ -142,7 +139,7 @@ fn pv_create(name: &str, storage: u32) -> PersistentVolume {
     labels.insert("app".to_owned(), "postgresql".to_owned());
     labels.insert("type".to_owned(), "local".to_owned());
 
-    let mut size : String = storage.to_string().to_owned();
+    let mut size: String = storage.to_string().to_owned();
     size.push_str(&"Gi".to_owned());
 
     let mut cap: BTreeMap<String, Quantity> = BTreeMap::new();
@@ -175,7 +172,7 @@ fn pvc_create(name: &str, namespace: &str, storage: u32) -> PersistentVolumeClai
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
     labels.insert("app".to_owned(), "postgresql".to_owned());
 
-    let mut size : String = storage.to_string().to_owned();
+    let mut size: String = storage.to_string().to_owned();
     size.push_str(&"Gi".to_owned());
 
     let mut cap: BTreeMap<String, Quantity> = BTreeMap::new();

--- a/src/primary.rs
+++ b/src/primary.rs
@@ -16,8 +16,8 @@ use k8s_openapi::{
     apimachinery::pkg::apis::meta::v1::LabelSelector,
 };
 use kube::{
-    api::{DeleteParams, ObjectMeta, PostParams},
     Api, Client, Error,
+    api::{DeleteParams, ObjectMeta, PostParams},
 };
 use log::{info, trace};
 use std::collections::BTreeMap;
@@ -44,7 +44,8 @@ pub async fn primary_deploy(
     let deployment_api: Api<Deployment> = Api::namespaced(client, namespace);
     match deployment_api
         .create(&PostParams::default(), &deployment)
-        .await {
+        .await
+    {
         Ok(o) => {
             info!("Created Primary");
             return Ok(o);

--- a/src/services.rs
+++ b/src/services.rs
@@ -7,8 +7,8 @@
  */
 use k8s_openapi::api::core::v1::{Service, ServicePort, ServiceSpec};
 use kube::{
-    api::{DeleteParams, ObjectMeta, PostParams},
     Api, Client, Error,
+    api::{DeleteParams, ObjectMeta, PostParams},
 };
 use log::{info, trace};
 use std::collections::BTreeMap;


### PR DESCRIPTION
# Description:
Added a simple shell script for code formatting. 
Bumped the edition in the cargo.toml file which rustfmt also uses. 
Ran the formatter to get things in a consistent state now. 

# Test plan:
Make the formatter executable:
`chmod +x format.sh`
And then run it:
`./format.sh`