### PR TITLE
[#12] Panick: Missing k8s environment

### DIFF
--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -7,11 +7,12 @@
  */
 
 use kube::client::Client;
+use log::error;
+use std::process;
 
 pub async fn k8s_client() -> Client {
-    let kubernetes_client: Client = Client::try_default()
-        .await
-        .expect("Expected a valid KUBECONFIG environment variable.");
-
-    kubernetes_client
+    Client::try_default().await.unwrap_or_else(|_| {
+        error!("Fatal error: Expected a valid KUBECONFIG environment variable.");
+        process::exit(1);
+    })
 }


### PR DESCRIPTION
# Description:
When there isn't a valid k8s env var, pgopr whould log a fatal error and return 1

# Test plan:
Set the kubernetes config env var to a nonexistent file:
`export KUBECONFIG=/path/to/nonexistent/file`
Then run the install command:
`pgopr install`

You should see the error:
<img width="920" alt="image" src="https://github.com/user-attachments/assets/d0bc2a40-440e-411d-9a30-3dc65a6b482d" />
