### PR TITLE
[#29] Update dependencies and fix clippy warnings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ pgopr was created by the following authors:
 Jesper Pedersen <jesperpedersen.db@gmail.com>
 Cristian Guarino <cristian.guarino.j@gmail.com>
 Nick Boyadjian <nboyadjian95@gmail.com>
+Bhawesh Panwar <panwarbhawesh1112@gmail.com>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "Eclipse Public License 2.0"
 description = "PostgreSQL operator for Kubernetes"
 
 [dependencies]
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.49", features = ["full"] }
 kube = { version = "3.0", default-features = true, features = ["client", "derive", "runtime"] }
 k8s-openapi = { version = "0.27", default-features = true, features = ["v1_35"] }
 clap = { version = "4.5", default-features = false, features = ["std", "cargo", "help"] }
@@ -23,7 +23,7 @@ figment = { version = "0.10", features = ["env", "toml"] }
 futures = { version = "0.3" }
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_trace"] }
 log4rs = { version = "1.4" }
-schemars = { version = "1.1" }
+schemars = { version = "1.2" }
 serde = { version = "1.0" }
 serde_derive = { version = "1.0" }
 serde_json = { version = "1.0" }

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -69,7 +69,7 @@ pub async fn crd_deploy(client: Client) -> Result<CustomResourceDefinition, Erro
         info!("Created CRD");
     }
 
-    return result;
+    result
 }
 
 /// Delete the CustomResourceDefinition object
@@ -88,7 +88,7 @@ pub async fn crd_undeploy(client: Client) -> Result<(), Error> {
             info!("Deleted CRD");
         }
 
-        Err(e) => return Err(e.into()),
+        Err(e) => return Err(e),
     }
 
     Ok(())

--- a/src/persistent.rs
+++ b/src/persistent.rs
@@ -43,9 +43,9 @@ pub async fn persistent_volume_deploy(
     match pv_api.create(&pp, &pv).await {
         Ok(o) => {
             info!("Created PersistentVolume");
-            return Ok(o);
+            Ok(o)
         }
-        Err(e) => return Err(e.into()),
+        Err(e) => Err(e),
     }
 }
 
@@ -63,7 +63,7 @@ pub async fn persistent_volume_undeploy(client: Client, name: &str) -> Result<()
             info!("Deleted PersistentVolume");
         }
 
-        Err(e) => return Err(e.into()),
+        Err(e) => return Err(e),
     }
     Ok(())
 }
@@ -93,9 +93,9 @@ pub async fn persistent_volume_claim_deploy(
     match pvc_api.create(&pp, &pvc).await {
         Ok(o) => {
             info!("Created PersistentVolumeClaim");
-            return Ok(o);
+            Ok(o)
         }
-        Err(e) => return Err(e.into()),
+        Err(e) => Err(e),
     }
 }
 
@@ -118,7 +118,7 @@ pub async fn persistent_volume_claim_undeploy(
             info!("Deleted PersistentVolumeClaim");
         }
 
-        Err(e) => return Err(e.into()),
+        Err(e) => return Err(e),
     }
     Ok(())
 }
@@ -140,7 +140,7 @@ fn pv_create(name: &str, storage: u32) -> PersistentVolume {
     labels.insert("type".to_owned(), "local".to_owned());
 
     let mut size: String = storage.to_string().to_owned();
-    size.push_str(&"Gi".to_owned());
+    size.push_str("Gi");
 
     let mut cap: BTreeMap<String, Quantity> = BTreeMap::new();
     cap.insert("storage".to_owned(), Quantity(size));
@@ -173,7 +173,7 @@ fn pvc_create(name: &str, namespace: &str, storage: u32) -> PersistentVolumeClai
     labels.insert("app".to_owned(), "postgresql".to_owned());
 
     let mut size: String = storage.to_string().to_owned();
-    size.push_str(&"Gi".to_owned());
+    size.push_str("Gi");
 
     let mut cap: BTreeMap<String, Quantity> = BTreeMap::new();
     cap.insert("storage".to_owned(), Quantity(size));

--- a/src/primary.rs
+++ b/src/primary.rs
@@ -50,9 +50,9 @@ pub async fn primary_deploy(
     {
         Ok(o) => {
             info!("Created Primary");
-            return Ok(o);
+            Ok(o)
         }
-        Err(e) => return Err(e.into()),
+        Err(e) => Err(e),
     }
 }
 
@@ -71,7 +71,7 @@ pub async fn primary_undeploy(client: Client, name: &str, namespace: &str) -> Re
             info!("Deleted Primary");
         }
 
-        Err(e) => return Err(e.into()),
+        Err(e) => return Err(e),
     }
     Ok(())
 }

--- a/src/services.rs
+++ b/src/services.rs
@@ -35,7 +35,7 @@ pub async fn service_deploy(client: Client, name: &str, namespace: &str) -> Resu
         info!("Created Service");
     }
 
-    return result;
+    result
 }
 
 /// Deletes a service
@@ -53,7 +53,7 @@ pub async fn service_undeploy(client: Client, name: &str, namespace: &str) -> Re
             info!("Deleted Service");
         }
 
-        Err(e) => return Err(e.into()),
+        Err(e) => return Err(e),
     }
 
     Ok(())


### PR DESCRIPTION
Closes #29

Updated all dependencies to their latest minor versions as requested.

## Changes

### Dependency Updates
- **tokio**: `1.x` → `1.49`
- **schemars**: `1.1` → `1.2`
- All other dependencies verified and already at latest minor versions

### Code Quality
- Fixed 22 clippy warnings (needless returns, useless conversions, unnecessary `to_owned`, etc.)

## Testing

Verified the changes with the full installation flow:
```bash
make install
kind create cluster
pgopr install
pgopr provision primary
kubectl port-forward postgresql-xxx 5433:5432
psql -h localhost -p 5433 -U myuser --password mydb
pgopr retire primary
pgopr uninstall
kind delete cluster
```

### Results
- Build successful with no errors
- No clippy warnings
- Installation and provisioning worked correctly
- PostgreSQL pod deployed and accessible
- All commands executed successfully

## Notes
- Used minor version format (e.g., `1.49` instead of `1.49.0`) as suggested by @jesperpedersen to allow automatic patch updates
- `kube` and `k8s-openapi` were recently updated in #30, so no changes needed there