### PR TITLE
[#28] Refactor main.rs: Extract match arms into separate handler modules

### DIFF
--- a/src/handlers/cluster.rs
+++ b/src/handlers/cluster.rs
@@ -1,0 +1,62 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+use crate::{crd, k8s, persistent, primary, services};
+use kube::Client;
+use log::debug;
+
+/// Orchestrates the installation of the operator and its CRDs.
+pub async fn handle_install() {
+    super::print_header();
+    let client: Client = k8s::k8s_client().await;
+    let _ = crd::crd_deploy(client).await;
+}
+
+/// Orchestrates the uninstallation of the operator and its CRDs.
+pub async fn handle_uninstall() {
+    super::print_header();
+    let client: Client = k8s::k8s_client().await;
+    let _ = crd::crd_undeploy(client).await;
+}
+
+/// Provisions the primary database components (PV, PVC, Deployment, Service).
+pub async fn handle_provision_primary() {
+    super::print_header();
+    debug!("primary");
+    let client: Client = k8s::k8s_client().await;
+    let namespace = "default".to_owned();
+
+    let _pv =
+        persistent::persistent_volume_deploy(client.clone(), "postgresql-pv-volume", 5u32).await;
+    let _pvc = persistent::persistent_volume_claim_deploy(
+        client.clone(),
+        "postgresql-pv-claim",
+        &namespace,
+        5u32,
+    )
+    .await;
+    let _d = primary::primary_deploy(client.clone(), "postgresql", &namespace).await;
+    let _s = services::service_deploy(client.clone(), "postgresql", &namespace).await;
+}
+
+/// Removes the primary database components.
+pub async fn handle_retire_primary() {
+    super::print_header();
+    debug!("primary");
+    let client: Client = k8s::k8s_client().await;
+    let namespace = "default".to_owned();
+
+    let _s = services::service_undeploy(client.clone(), "postgresql", &namespace).await;
+    let _d = primary::primary_undeploy(client.clone(), "postgresql", &namespace).await;
+    let _pvc = persistent::persistent_volume_claim_undeploy(
+        client.clone(),
+        "postgresql-pv-claim",
+        &namespace,
+    )
+    .await;
+    let _pv = persistent::persistent_volume_undeploy(client.clone(), "postgresql-pv-volume").await;
+}

--- a/src/handlers/generate.rs
+++ b/src/handlers/generate.rs
@@ -1,0 +1,34 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+use crate::{crd, persistent, primary, services};
+use clap::ArgMatches;
+
+/// Handles the 'generate' subcommand logic for various resource types.
+///
+/// # Arguments:
+/// - `sub_matches` - The arguments passed to the generate subcommand.
+pub fn handle_generate(sub_matches: &ArgMatches) {
+    match *sub_matches.get_one::<&str>("type").unwrap() {
+        "crd" => {
+            crd::crd_generate();
+        }
+        "service" => {
+            services::service_generate();
+        }
+        "persistent" => {
+            persistent::persistent_generate();
+        }
+        "primary" => {
+            primary::primary_generate();
+        }
+        name => {
+            unreachable!("Unsupported type `{}`", name)
+        }
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,0 +1,20 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+pub mod cluster;
+pub mod generate;
+pub mod operator;
+
+use clap::{crate_description, crate_name, crate_version};
+use log::info;
+
+// Helper to remove that repeated block from main.rs
+pub fn print_header() {
+    info!("{} {}", crate_name!(), crate_version!());
+    info!("{}", crate_description!());
+}

--- a/src/handlers/operator.rs
+++ b/src/handlers/operator.rs
@@ -1,0 +1,39 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+use crate::{ContextData, k8s, on_error, pgopr, reconcile};
+use futures::StreamExt;
+use kube::{
+    Api, Client,
+    runtime::{Controller, watcher},
+};
+use log::{debug, error};
+use std::sync::Arc;
+
+/// Initializes and starts the Kubernetes controller loop for pgopr resources.
+pub async fn run_operator() {
+    super::print_header();
+
+    let client: Client = k8s::k8s_client().await;
+    let crd_api: Api<pgopr> = Api::all(client.clone());
+    let context: Arc<ContextData> = Arc::new(ContextData::new(client.clone()));
+
+    // Start the controller
+    Controller::new(crd_api.clone(), watcher::Config::default())
+        .run(reconcile, on_error, context)
+        .for_each(|reconciliation_result| async move {
+            match reconciliation_result {
+                Ok(pgopr_resource) => {
+                    debug!("Reconciliation successful. Resource: {:?}", pgopr_resource);
+                }
+                Err(reconciliation_err) => {
+                    error!("Reconciliation error: {:?}", reconciliation_err)
+                }
+            }
+        })
+        .await;
+}


### PR DESCRIPTION
Closes #28

This PR addresses the issue of a bloated `main.rs` by extracting the extensive logic found within the CLI match statement into a new modular structure. The goal is to improve code readability, maintainability, and allow for easier testing of individual command branches.

## Key Changes

### New Module Structure
Introduced a `src/handlers/` directory to organize logic by domain:
- **handlers/mod.rs**: Module entry point and shared logging helpers
- **handlers/generate.rs**: Handles all YAML generation logic (crd, service, persistent, primary)
- **handlers/cluster.rs**: Orchestrates cluster-wide lifecycle actions (install, uninstall, provision, retire)
- **handlers/operator.rs**: Encapsulates the main Kubernetes controller loop and reconciliation initiation

### Refactored main.rs
- Simplified the main function to act strictly as a router
- Reduced `main.rs` line count significantly
- Created a shared `print_header()` helper to eliminate code duplication for logging app metadata
- Updated visibility for `ContextData`, `on_error` to `pub(crate)` to allow access from the new handler modules


## Files Changed

| File | Purpose |
|------|---------|
| `src/main.rs` | Cleaned up CLI routing; logic moved to handlers |
| `src/handlers/mod.rs` | Module entry point and shared logging helpers |
| `src/handlers/generate.rs` | Logic for the generate subcommand |
| `src/handlers/cluster.rs` | Logic for install, uninstall, provision, and retire |
| `src/handlers/operator.rs` | Logic for the default operator/controller loop |

## Testing

### Build Verification
```bash
cargo build --release    # Compiles without warnings
cargo clippy             # No warnings
cargo fmt --check        # Code properly formatted
```

### CLI Commands Tested
```bash
pgopr install                    # CRD created successfully
pgopr provision primary          # PostgreSQL deployed
kubectl get pods                 # Pod running (1/1)
kubectl port-forward <pod> 5433:5432  # Port forwarding works
pgopr retire primary             # Resources cleaned up
pgopr uninstall                  # CRD deleted
```

### Test Results
- All commands execute without errors
- Log output shows proper module paths (`pgopr::handlers`)
- PostgreSQL pod provisions and runs correctly (0/1 → 1/1 Running)
- Cleanup operations complete successfully
- Header (Name, Version, Description) prints correctly for each command
- No functional logic was changed (pure refactor)

