### PR TITLE
[#20] Add automatic kind cleanup to CI script

### DIFF
--- a/test/check.sh
+++ b/test/check.sh
@@ -160,6 +160,7 @@ esac
 done
 
 if [[ "$SUBCOMMAND" == "ci" ]]; then
+    trap cleanup_cluster EXIT
     setup_cluster
     build_operator
     test_operator


### PR DESCRIPTION
This is a small follow-up to the CI integration work. It adds a `trap` in the [test/check.sh](cci:7://file:///Users/sakshii/pgopr/test/check.sh:0:0-0:0) script to ensure that the `kind` cluster is automatically deleted on exit.

Ref #20
