### PR TITLE
Fix license header in test script

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Cristian Guarino <cristian.guarino.j@gmail.com>
 Nick Boyadjian <nboyadjian95@gmail.com>
 Bhawesh Panwar <panwarbhawesh1112@gmail.com>
 Sakshii-27 <sakshiaggarwal2706@gmail.com>
+Frank Heikens <frank@elevarq.com>

--- a/test/check.sh
+++ b/test/check.sh
@@ -1,18 +1,9 @@
 #!/bin/bash
-## Copyright (C) 2026 The pgmoneta community
+## Eclipse Public License - v 2.0
 ##
-## This program is free software: you can redistribute it and/or modify
-## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation, either version 3 of the License, or
-## (at your option) any later version.
-##
-## This program is distributed in the hope that it will be useful,
-## but WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-## GNU General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with this program. If not, see <https://www.gnu.org/licenses/>.
+##   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+##   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+##   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
 set -euo pipefail
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
The header in test/check.sh does not match the project.

It references pgmoneta and GPL-3.0 text, while pgopr uses EPL-2.0 in the
rest of the repository.

Replace the copied header with the EPL-2.0 notice used elsewhere in pgopr.

No functional change.