### PR TITLE
Fix CRD name in await_condition during install

### DIFF
--- a/src/crd.rs
+++ b/src/crd.rs
@@ -62,7 +62,7 @@ pub async fn crd_deploy(client: Client) -> Result<CustomResourceDefinition, Erro
     let result: Result<CustomResourceDefinition, Error> =
         crd_api.create(&PostParams::default(), &crd).await;
 
-    let establish = await_condition(crd_api, "pgopr.io", conditions::is_crd_established());
+    let establish = await_condition(crd_api, "pgoprs.pgopr.io", conditions::is_crd_established());
     let _ = tokio::time::timeout(std::time::Duration::from_secs(10), establish).await;
 
     if result.is_ok() {


### PR DESCRIPTION
Fixes #42

The `await_condition` call in `crd_deploy` uses `"pgopr.io"` as the CRD object
name. That is the API group name, not the actual CRD object name.

The CRD object is named `pgoprs.pgopr.io`, which is already used correctly in
`crd_undeploy`.

This change makes the install path wait for the correct CRD resource to become
established instead of timing out on a non-existent object.