### PR TITLE
[#34] Add replica provisioning support

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -38,6 +38,7 @@ We will run `pgopr` using the follow commands
 kind create cluster
 pgopr install
 pgopr provision primary
+pgopr provision replica
 kubectl get services
 kubectl port-forward postgresql-XYZ 5432:5432
 psql -h localhost -p 5432 -U myuser mydb
@@ -48,6 +49,7 @@ using `mypass` as the password.
 To shutdown the operator use
 
 ```
+pgopr retire replica
 pgopr retire primary
 pgopr uninstall
 kind delete cluster

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -35,6 +35,8 @@ pub mod v1 {
     pub struct PgOprSpec {
         /// General settings across all components
         pub storage: u32,
+        /// Number of replicas in the star configuration
+        pub replicas: Option<u32>,
     }
 
     /// The general settings

--- a/src/handlers/cluster.rs
+++ b/src/handlers/cluster.rs
@@ -30,13 +30,20 @@ pub async fn handle_provision_primary() {
     let client: Client = k8s::k8s_client().await;
     let namespace = "default".to_owned();
 
-    let _pv =
-        persistent::persistent_volume_deploy(client.clone(), "postgresql-pv-volume", 5u32).await;
+    let _pv = persistent::persistent_volume_deploy(
+        client.clone(),
+        "postgresql-pv-volume",
+        5u32,
+        "postgresql",
+        "/tmp/kind",
+    )
+    .await;
     let _pvc = persistent::persistent_volume_claim_deploy(
         client.clone(),
         "postgresql-pv-claim",
         &namespace,
         5u32,
+        "postgresql",
     )
     .await;
     let _d = primary::primary_deploy(client.clone(), "postgresql", &namespace).await;
@@ -59,4 +66,59 @@ pub async fn handle_retire_primary() {
     )
     .await;
     let _pv = persistent::persistent_volume_undeploy(client.clone(), "postgresql-pv-volume").await;
+}
+
+/// Provisions the replica database components (PV, PVC, Deployment, Service).
+pub async fn handle_provision_replica() {
+    super::print_header();
+    debug!("replica");
+    let client: Client = k8s::k8s_client().await;
+    let namespace = "default".to_owned();
+
+    let _pv = persistent::persistent_volume_deploy(
+        client.clone(),
+        "postgresql-replica-pv-volume",
+        5u32,
+        "postgresql-replica",
+        "/tmp/kind-replica",
+    )
+    .await;
+    let _pvc = persistent::persistent_volume_claim_deploy(
+        client.clone(),
+        "postgresql-replica-pv-claim",
+        &namespace,
+        5u32,
+        "postgresql-replica",
+    )
+    .await;
+    let _d = crate::replica::replica_deploy(
+        client.clone(),
+        "postgresql-replica",
+        "postgresql",
+        &namespace,
+        "replica1",
+    )
+    .await;
+    let _s = services::service_deploy(client.clone(), "postgresql-replica", &namespace).await;
+}
+
+/// Removes the replica database components.
+pub async fn handle_retire_replica() {
+    super::print_header();
+    debug!("replica");
+    let client: Client = k8s::k8s_client().await;
+    let namespace = "default".to_owned();
+
+    let _s = services::service_undeploy(client.clone(), "postgresql-replica", &namespace).await;
+    let _d =
+        crate::replica::replica_undeploy(client.clone(), "postgresql-replica", &namespace).await;
+    let _pvc = persistent::persistent_volume_claim_undeploy(
+        client.clone(),
+        "postgresql-replica-pv-claim",
+        &namespace,
+    )
+    .await;
+    let _pv =
+        persistent::persistent_volume_undeploy(client.clone(), "postgresql-replica-pv-volume")
+            .await;
 }

--- a/src/handlers/generate.rs
+++ b/src/handlers/generate.rs
@@ -14,7 +14,7 @@ use clap::ArgMatches;
 /// # Arguments:
 /// - `sub_matches` - The arguments passed to the generate subcommand.
 pub fn handle_generate(sub_matches: &ArgMatches) {
-    match *sub_matches.get_one::<&str>("type").unwrap() {
+    match sub_matches.get_one::<String>("type").unwrap().as_str() {
         "crd" => {
             crd::crd_generate();
         }
@@ -26,6 +26,9 @@ pub fn handle_generate(sub_matches: &ArgMatches) {
         }
         "primary" => {
             primary::primary_generate();
+        }
+        "replica" => {
+            crate::replica::replica_generate();
         }
         name => {
             unreachable!("Unsupported type `{}`", name)

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ pub mod handlers;
 mod k8s;
 mod persistent;
 mod primary;
+mod replica;
 mod services;
 
 /// Context injected with each `reconcile` and `on_error` method invocation
@@ -87,6 +88,11 @@ fn cli() -> Command {
                     Command::new("primary")
                         .about("Provision a primary instance")
                         .display_order(1),
+                )
+                .subcommand(
+                    Command::new("replica")
+                        .about("Provision a replica instance")
+                        .display_order(2),
                 ),
         )
         .subcommand(
@@ -98,6 +104,11 @@ fn cli() -> Command {
                     Command::new("primary")
                         .about("Retire a primary instance")
                         .display_order(1),
+                )
+                .subcommand(
+                    Command::new("replica")
+                        .about("Retire a replica instance")
+                        .display_order(2),
                 ),
         )
         .subcommand(
@@ -127,7 +138,7 @@ fn cli() -> Command {
                         .short('t')
                         .long("type")
                         .required(true)
-                        .value_parser(vec!["crd", "service", "persistent", "primary"])
+                        .value_parser(vec!["crd", "service", "persistent", "primary", "replica"])
                         .help("Generate YAML resources"),
                 ),
         )
@@ -175,6 +186,7 @@ async fn main() {
             let (name, _) = sub_matches.subcommand().unwrap_or(("primary", sub_matches));
             match name {
                 "primary" => handlers::cluster::handle_provision_primary().await,
+                "replica" => handlers::cluster::handle_provision_replica().await,
                 name => unreachable!("Unsupported subcommand `{}`", name),
             }
         }
@@ -183,6 +195,7 @@ async fn main() {
             let (name, _) = sub_matches.subcommand().unwrap_or(("primary", sub_matches));
             match name {
                 "primary" => handlers::cluster::handle_retire_primary().await,
+                "replica" => handlers::cluster::handle_retire_replica().await,
                 name => unreachable!("Unsupported subcommand `{}`", name),
             }
         }
@@ -220,16 +233,37 @@ async fn reconcile(pgopr: Arc<pgopr>, context: Arc<ContextData>) -> Result<Actio
     match determine_action(&pgopr) {
         PgOprAction::CreatePrimary => {
             let name = pgopr.name_any();
+            let replicas = pgopr.spec.replicas.unwrap_or(0);
 
             finalizer::add(client.clone(), &name, &namespace).await?;
-            primary::primary_deploy(client, &pgopr.name_any(), &namespace).await?;
+            primary::primary_deploy(client.clone(), &name, &namespace).await?;
+
+            for i in 1..=replicas {
+                let replica_name = format!("{}-replica-{}", name, i);
+                let slot_name = format!("replica{}", i);
+                crate::replica::replica_deploy(
+                    client.clone(),
+                    &replica_name,
+                    &name,
+                    &namespace,
+                    &slot_name,
+                )
+                .await?;
+            }
 
             Ok(Action::requeue(Duration::from_secs(10)))
         }
 
         PgOprAction::DeletePrimary => {
-            primary::primary_undeploy(client.clone(), &pgopr.name_any(), &namespace).await?;
-            finalizer::delete(client, &pgopr.name_any(), &namespace).await?;
+            let name = pgopr.name_any();
+            let replicas = pgopr.spec.replicas.unwrap_or(0);
+
+            for i in 1..=replicas {
+                let replica_name = format!("{}-replica-{}", name, i);
+                crate::replica::replica_undeploy(client.clone(), &replica_name, &namespace).await?;
+            }
+            primary::primary_undeploy(client.clone(), &name, &namespace).await?;
+            finalizer::delete(client, &name, &namespace).await?;
 
             Ok(Action::await_change())
         }

--- a/src/persistent.rs
+++ b/src/persistent.rs
@@ -32,9 +32,11 @@ pub async fn persistent_volume_deploy(
     client: Client,
     name: &str,
     storage: u32,
+    label_app: &str,
+    host_path: &str,
 ) -> Result<PersistentVolume, Error> {
     // Definition of the persistent volume
-    let pv: PersistentVolume = pv_create(name, storage);
+    let pv: PersistentVolume = pv_create(name, storage, label_app, host_path);
     trace!("pv: {:?}", pv);
 
     // Create the persistent volume defined above
@@ -82,9 +84,10 @@ pub async fn persistent_volume_claim_deploy(
     name: &str,
     namespace: &str,
     storage: u32,
+    label_app: &str,
 ) -> Result<PersistentVolumeClaim, Error> {
     // Definition of the persistent volume claim
-    let pvc: PersistentVolumeClaim = pvc_create(name, namespace, storage);
+    let pvc: PersistentVolumeClaim = pvc_create(name, namespace, storage, label_app);
     trace!("pvc: {:?}", pvc);
 
     // Create the persistent volume claim defined above
@@ -125,18 +128,28 @@ pub async fn persistent_volume_claim_undeploy(
 
 /// Persistent: Generate
 pub fn persistent_generate() {
-    let pv = serde_yaml::to_string(&pv_create("postgresql-pv-volume", 5u32))
-        .expect("Can't serialize pgopr-pv.yaml");
+    let pv = serde_yaml::to_string(&pv_create(
+        "postgresql-pv-volume",
+        5u32,
+        "postgresql",
+        "/tmp/kind",
+    ))
+    .expect("Can't serialize pgopr-pv.yaml");
     fs::write("pgopr-pv.yaml", pv).expect("Unable to write file: pgopr-pv.yaml");
 
-    let pvc = serde_yaml::to_string(&pvc_create("postgresql-pv-claim", "default", 5u32))
-        .expect("Can't serialize pgopr-pvc.yaml");
+    let pvc = serde_yaml::to_string(&pvc_create(
+        "postgresql-pv-claim",
+        "default",
+        5u32,
+        "postgresql",
+    ))
+    .expect("Can't serialize pgopr-pvc.yaml");
     fs::write("pgopr-pvc.yaml", pvc).expect("Unable to write file: pgopr-pvc.yaml");
 }
 
-fn pv_create(name: &str, storage: u32) -> PersistentVolume {
+fn pv_create(name: &str, storage: u32, label_app: &str, host_path: &str) -> PersistentVolume {
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
-    labels.insert("app".to_owned(), "postgresql".to_owned());
+    labels.insert("app".to_owned(), label_app.to_owned());
     labels.insert("type".to_owned(), "local".to_owned());
 
     let mut size: String = storage.to_string().to_owned();
@@ -157,7 +170,7 @@ fn pv_create(name: &str, storage: u32) -> PersistentVolume {
             capacity: Some(cap.clone()),
             access_modes: Some(vec!["ReadWriteMany".to_owned()]),
             host_path: Some(HostPathVolumeSource {
-                path: "/tmp/kind".to_owned(),
+                path: host_path.to_owned(),
                 ..HostPathVolumeSource::default()
             }),
             ..PersistentVolumeSpec::default()
@@ -168,9 +181,9 @@ fn pv_create(name: &str, storage: u32) -> PersistentVolume {
     pv
 }
 
-fn pvc_create(name: &str, namespace: &str, storage: u32) -> PersistentVolumeClaim {
+fn pvc_create(name: &str, namespace: &str, storage: u32, label_app: &str) -> PersistentVolumeClaim {
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
-    labels.insert("app".to_owned(), "postgresql".to_owned());
+    labels.insert("app".to_owned(), label_app.to_owned());
 
     let mut size: String = storage.to_string().to_owned();
     size.push_str("Gi");

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -5,7 +5,7 @@
  *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
  *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
  */
-const PRIMARY_IMAGE: &str = "pgsql18-primary-rocky10";
+const REPLICA_IMAGE: &str = "pgsql18-replica-rocky10";
 
 use k8s_openapi::{
     api::{
@@ -25,7 +25,7 @@ use log::{info, trace};
 use std::collections::BTreeMap;
 use std::fs;
 
-/// Creates a primary deployment
+/// Creates a replica deployment
 ///
 /// # Arguments
 /// - `client` - A Kubernetes client to create the deployment with
@@ -33,13 +33,15 @@ use std::fs;
 /// - `namespace` - Namespace to create the Kubernetes Deployment in
 ///
 /// Note: It is assumed the resource does not already exists for simplicity. Returns an `Error` if it does
-pub async fn primary_deploy(
+pub async fn replica_deploy(
     client: Client,
     name: &str,
+    primary_name: &str,
     namespace: &str,
+    slot_name: &str,
 ) -> Result<Deployment, Error> {
     // Definition of the deployment
-    let deployment: Deployment = primary_create(name, namespace);
+    let deployment: Deployment = replica_create(name, primary_name, namespace, slot_name);
     trace!("d: {:?}", deployment);
 
     // Create the deployment defined above
@@ -49,14 +51,14 @@ pub async fn primary_deploy(
         .await
     {
         Ok(o) => {
-            info!("Created Primary");
+            info!("Created Replica");
             Ok(o)
         }
         Err(e) => Err(e),
     }
 }
 
-/// Deletes an existing primary deployment.
+/// Deletes an existing replica deployment.
 ///
 /// # Arguments:
 /// - `client` - A Kubernetes client to delete the Deployment with
@@ -64,11 +66,11 @@ pub async fn primary_deploy(
 /// - `namespace` - Namespace the existing deployment resides in
 ///
 /// Note: It is assumed the deployment exists for simplicity. Otherwise returns an Error.
-pub async fn primary_undeploy(client: Client, name: &str, namespace: &str) -> Result<(), Error> {
+pub async fn replica_undeploy(client: Client, name: &str, namespace: &str) -> Result<(), Error> {
     let api: Api<Deployment> = Api::namespaced(client, namespace);
     match api.delete(name, &DeleteParams::default()).await {
         Ok(_) => {
-            info!("Deleted Primary");
+            info!("Deleted Replica");
         }
 
         Err(e) => return Err(e),
@@ -76,14 +78,19 @@ pub async fn primary_undeploy(client: Client, name: &str, namespace: &str) -> Re
     Ok(())
 }
 
-/// Primary: Generate
-pub fn primary_generate() {
-    let data = serde_yaml::to_string(&primary_create("postgresql", "default"))
-        .expect("Can't serialize pgopr-primary.yaml");
-    fs::write("pgopr-primary.yaml", data).expect("Unable to write file: pgopr-primary.yaml");
+/// Replica: Generate
+pub fn replica_generate() {
+    let data = serde_yaml::to_string(&replica_create(
+        "postgresql-replica",
+        "postgresql",
+        "default",
+        "replica1",
+    ))
+    .expect("Can't serialize pgopr-replica.yaml");
+    fs::write("pgopr-replica.yaml", data).expect("Unable to write file: pgopr-replica.yaml");
 }
 
-fn primary_create(name: &str, namespace: &str) -> Deployment {
+fn replica_create(name: &str, primary_name: &str, namespace: &str, slot_name: &str) -> Deployment {
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
     labels.insert("app".to_owned(), name.to_owned());
 
@@ -104,7 +111,7 @@ fn primary_create(name: &str, namespace: &str) -> Deployment {
                 spec: Some(PodSpec {
                     containers: vec![Container {
                         name: name.to_owned(),
-                        image: Some(PRIMARY_IMAGE.to_string()),
+                        image: Some(REPLICA_IMAGE.to_string()),
                         image_pull_policy: Some("IfNotPresent".to_string()),
                         ports: Some(vec![ContainerPort {
                             container_port: 5432,
@@ -112,18 +119,8 @@ fn primary_create(name: &str, namespace: &str) -> Deployment {
                         }]),
                         env: Some(vec![
                             EnvVar {
-                                name: "PG_DATABASE".to_string(),
-                                value: Some("mydb".to_string()),
-                                ..EnvVar::default()
-                            },
-                            EnvVar {
-                                name: "PG_USER_NAME".to_string(),
-                                value: Some("myuser".to_string()),
-                                ..EnvVar::default()
-                            },
-                            EnvVar {
-                                name: "PG_USER_PASSWORD".to_string(),
-                                value: Some("mypass".to_string()),
+                                name: "PG_PRIMARY".to_string(),
+                                value: Some(primary_name.to_string()),
                                 ..EnvVar::default()
                             },
                             EnvVar {
@@ -137,35 +134,20 @@ fn primary_create(name: &str, namespace: &str) -> Deployment {
                                 ..EnvVar::default()
                             },
                             EnvVar {
-                                name: "PG_BACKUP_NAME".to_string(),
-                                value: Some("backup_user".to_string()),
-                                ..EnvVar::default()
-                            },
-                            EnvVar {
-                                name: "PG_BACKUP_PASSWORD".to_string(),
-                                value: Some("backup_pass".to_string()),
-                                ..EnvVar::default()
-                            },
-                            EnvVar {
-                                name: "PG_BACKUP_SLOT".to_string(),
-                                value: Some("backup".to_string()),
-                                ..EnvVar::default()
-                            },
-                            EnvVar {
-                                name: "PG_NETWORK_MASK".to_string(),
-                                value: Some("all".to_string()),
+                                name: "PG_SLOT_NAME".to_string(),
+                                value: Some(slot_name.to_string()),
                                 ..EnvVar::default()
                             },
                         ]),
                         volume_mounts: Some(vec![VolumeMount {
-                            name: "mydb".to_string(),
+                            name: "mydb-replica".to_string(),
                             mount_path: "/pgdata".to_string(),
                             ..VolumeMount::default()
                         }]),
                         ..Container::default()
                     }],
                     volumes: Some(vec![Volume {
-                        name: "mydb".to_string(),
+                        name: "mydb-replica".to_string(),
                         persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource {
                             claim_name: format!("{}-pv-claim", name),
                             ..PersistentVolumeClaimVolumeSource::default()

--- a/src/services.rs
+++ b/src/services.rs
@@ -68,7 +68,7 @@ pub fn service_generate() {
 
 fn service_create(name: &str, namespace: &str) -> Service {
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
-    labels.insert("app".to_owned(), "postgresql".to_owned());
+    labels.insert("app".to_owned(), name.to_owned());
 
     let s: Service = Service {
         metadata: ObjectMeta {


### PR DESCRIPTION
Closes #34
This PR adds support for deploying PostgreSQL replicas. 

* **Upgraded the Primary Database**: Switched the primary component to use our new custom image (`pgsql18-primary-rocky10`) and passed in the required environment variables for replication.
* **Added Replica Support**: Created the setup for the replica database using `pgsql18-replica-rocky10`. It automatically points to the primary database to begin replicating data.
* **Separated Storage**: Updated the storage creation logic so the primary and replica databases each securely get their own separate storage folders without clashing.
* **New CLI Commands**: Added `pgopr provision replica` and `pgopr retire replica` so you can easily spin the replicas up or shut them down.
* **Automatic Deployment**: Updated the main operator loop so it correctly deploys both the primary and its replica together.



