### PR TITLE
[#36] Add pgexporter provisioning support

### DIFF
--- a/src/handlers/cluster.rs
+++ b/src/handlers/cluster.rs
@@ -5,7 +5,7 @@
  *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
  *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
  */
-use crate::{crd, k8s, persistent, primary, services};
+use crate::{crd, k8s, persistent, pgexporter, primary, services};
 use kube::Client;
 use log::debug;
 
@@ -47,7 +47,7 @@ pub async fn handle_provision_primary() {
     )
     .await;
     let _d = primary::primary_deploy(client.clone(), "postgresql", &namespace).await;
-    let _s = services::service_deploy(client.clone(), "postgresql", &namespace).await;
+    let _s = services::service_deploy(client.clone(), "postgresql", &namespace, 5432).await;
 }
 
 /// Removes the primary database components.
@@ -99,7 +99,37 @@ pub async fn handle_provision_replica() {
         "replica1",
     )
     .await;
-    let _s = services::service_deploy(client.clone(), "postgresql-replica", &namespace).await;
+    let _s = services::service_deploy(client.clone(), "postgresql-replica", &namespace, 5432).await;
+}
+
+/// Provisions pgexporter (Deployment, Service).
+pub async fn handle_provision_pgexporter() {
+    super::print_header();
+    debug!("pgexporter");
+    let client: Client = k8s::k8s_client().await;
+    let namespace = "default".to_owned();
+
+    let _d = pgexporter::pgexporter_deploy(
+        client.clone(),
+        "postgresql-pgexporter",
+        "postgresql",
+        &namespace,
+    )
+    .await;
+    let _s =
+        services::service_deploy(client.clone(), "postgresql-pgexporter", &namespace, 5002).await;
+}
+
+/// Removes pgexporter components.
+pub async fn handle_retire_pgexporter() {
+    super::print_header();
+    debug!("pgexporter");
+    let client: Client = k8s::k8s_client().await;
+    let namespace = "default".to_owned();
+
+    let _s = services::service_undeploy(client.clone(), "postgresql-pgexporter", &namespace).await;
+    let _d =
+        pgexporter::pgexporter_undeploy(client.clone(), "postgresql-pgexporter", &namespace).await;
 }
 
 /// Removes the replica database components.

--- a/src/handlers/generate.rs
+++ b/src/handlers/generate.rs
@@ -6,7 +6,7 @@
  *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
  */
 
-use crate::{crd, persistent, primary, services};
+use crate::{crd, persistent, pgexporter, primary, services};
 use clap::ArgMatches;
 
 /// Handles the 'generate' subcommand logic for various resource types.
@@ -29,6 +29,9 @@ pub fn handle_generate(sub_matches: &ArgMatches) {
         }
         "replica" => {
             crate::replica::replica_generate();
+        }
+        "pgexporter" => {
+            pgexporter::pgexporter_generate();
         }
         name => {
             unreachable!("Unsupported type `{}`", name)

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod finalizer;
 pub mod handlers;
 mod k8s;
 mod persistent;
+mod pgexporter;
 mod primary;
 mod replica;
 mod services;
@@ -93,6 +94,11 @@ fn cli() -> Command {
                     Command::new("replica")
                         .about("Provision a replica instance")
                         .display_order(2),
+                )
+                .subcommand(
+                    Command::new("pgexporter")
+                        .about("Provision a pgexporter instance")
+                        .display_order(3),
                 ),
         )
         .subcommand(
@@ -109,6 +115,11 @@ fn cli() -> Command {
                     Command::new("replica")
                         .about("Retire a replica instance")
                         .display_order(2),
+                )
+                .subcommand(
+                    Command::new("pgexporter")
+                        .about("Retire a pgexporter instance")
+                        .display_order(3),
                 ),
         )
         .subcommand(
@@ -138,7 +149,14 @@ fn cli() -> Command {
                         .short('t')
                         .long("type")
                         .required(true)
-                        .value_parser(vec!["crd", "service", "persistent", "primary", "replica"])
+                        .value_parser(vec![
+                            "crd",
+                            "service",
+                            "persistent",
+                            "primary",
+                            "replica",
+                            "pgexporter",
+                        ])
                         .help("Generate YAML resources"),
                 ),
         )
@@ -187,6 +205,7 @@ async fn main() {
             match name {
                 "primary" => handlers::cluster::handle_provision_primary().await,
                 "replica" => handlers::cluster::handle_provision_replica().await,
+                "pgexporter" => handlers::cluster::handle_provision_pgexporter().await,
                 name => unreachable!("Unsupported subcommand `{}`", name),
             }
         }
@@ -196,6 +215,7 @@ async fn main() {
             match name {
                 "primary" => handlers::cluster::handle_retire_primary().await,
                 "replica" => handlers::cluster::handle_retire_replica().await,
+                "pgexporter" => handlers::cluster::handle_retire_pgexporter().await,
                 name => unreachable!("Unsupported subcommand `{}`", name),
             }
         }

--- a/src/pgexporter.rs
+++ b/src/pgexporter.rs
@@ -1,0 +1,153 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+const PGEXPORTER_IMAGE: &str = "pgexporter-rocky10";
+
+use k8s_openapi::{
+    api::{
+        apps::v1::{Deployment, DeploymentSpec},
+        core::v1::{Container, ContainerPort, EnvVar, PodSpec, PodTemplateSpec},
+    },
+    apimachinery::pkg::apis::meta::v1::LabelSelector,
+};
+use kube::{
+    Api, Client, Error,
+    api::{DeleteParams, ObjectMeta, PostParams},
+};
+use log::{info, trace};
+use std::collections::BTreeMap;
+use std::fs;
+
+/// Creates a pgexporter deployment
+///
+/// # Arguments
+/// - `client` - A Kubernetes client to create the deployment with
+/// - `name` - Name of the deployment to be created
+/// - `primary_name` - Name of the primary to monitor
+/// - `namespace` - Namespace to create the Kubernetes Deployment in
+///
+/// Note: It is assumed the resource does not already exists for simplicity. Returns an `Error` if it does
+pub async fn pgexporter_deploy(
+    client: Client,
+    name: &str,
+    primary_name: &str,
+    namespace: &str,
+) -> Result<Deployment, Error> {
+    // Definition of the deployment
+    let deployment: Deployment = pgexporter_create(name, primary_name, namespace);
+    trace!("d: {:?}", deployment);
+
+    // Create the deployment defined above
+    let deployment_api: Api<Deployment> = Api::namespaced(client, namespace);
+    match deployment_api
+        .create(&PostParams::default(), &deployment)
+        .await
+    {
+        Ok(o) => {
+            info!("Created pgexporter");
+            Ok(o)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Deletes an existing pgexporter deployment.
+///
+/// # Arguments:
+/// - `client` - A Kubernetes client to delete the Deployment with
+/// - `name` - Name of the deployment to delete
+/// - `namespace` - Namespace the existing deployment resides in
+///
+/// Note: It is assumed the deployment exists for simplicity. Otherwise returns an Error.
+pub async fn pgexporter_undeploy(client: Client, name: &str, namespace: &str) -> Result<(), Error> {
+    let api: Api<Deployment> = Api::namespaced(client, namespace);
+    match api.delete(name, &DeleteParams::default()).await {
+        Ok(_) => {
+            info!("Deleted pgexporter");
+        }
+
+        Err(e) => return Err(e),
+    }
+    Ok(())
+}
+
+/// pgexporter: Generate
+pub fn pgexporter_generate() {
+    let data = serde_yaml::to_string(&pgexporter_create(
+        "postgresql-pgexporter",
+        "postgresql",
+        "default",
+    ))
+    .expect("Can't serialize pgopr-pgexporter.yaml");
+    fs::write("pgopr-pgexporter.yaml", data).expect("Unable to write file: pgopr-pgexporter.yaml");
+}
+
+fn pgexporter_create(name: &str, primary_name: &str, namespace: &str) -> Deployment {
+    let mut labels: BTreeMap<String, String> = BTreeMap::new();
+    labels.insert("app".to_owned(), name.to_owned());
+
+    // Definition of the deployment
+    let deployment: Deployment = Deployment {
+        metadata: ObjectMeta {
+            name: Some(name.to_owned()),
+            namespace: Some(namespace.to_owned()),
+            ..ObjectMeta::default()
+        },
+        spec: Some(DeploymentSpec {
+            replicas: Some(1i32),
+            selector: LabelSelector {
+                match_expressions: None,
+                match_labels: Some(labels.clone()),
+            },
+            template: PodTemplateSpec {
+                spec: Some(PodSpec {
+                    containers: vec![Container {
+                        name: name.to_owned(),
+                        image: Some(PGEXPORTER_IMAGE.to_string()),
+                        image_pull_policy: Some("IfNotPresent".to_string()),
+                        ports: Some(vec![ContainerPort {
+                            container_port: 5002,
+                            ..ContainerPort::default()
+                        }]),
+                        env: Some(vec![
+                            EnvVar {
+                                name: "PG_PRIMARY_NAME".to_string(),
+                                value: Some(primary_name.to_string()),
+                                ..EnvVar::default()
+                            },
+                            EnvVar {
+                                name: "PG_PRIMARY_PORT".to_string(),
+                                value: Some("5432".to_string()),
+                                ..EnvVar::default()
+                            },
+                            EnvVar {
+                                name: "PG_EXPORTER_NAME".to_string(),
+                                value: Some("pgexporter".to_string()),
+                                ..EnvVar::default()
+                            },
+                            EnvVar {
+                                name: "PG_EXPORTER_PASSWORD".to_string(),
+                                value: Some("pgexporter".to_string()),
+                                ..EnvVar::default()
+                            },
+                        ]),
+                        ..Container::default()
+                    }],
+                    ..PodSpec::default()
+                }),
+                metadata: Some(ObjectMeta {
+                    labels: Some(labels.clone()),
+                    ..ObjectMeta::default()
+                }),
+            },
+            ..DeploymentSpec::default()
+        }),
+        ..Deployment::default()
+    };
+
+    deployment
+}

--- a/src/services.rs
+++ b/src/services.rs
@@ -22,9 +22,14 @@ use std::fs;
 /// - `namespace` - The namespace
 ///
 /// Note: It is assumed the service does not already exists for simplicity. Returns an `Error` if it does.
-pub async fn service_deploy(client: Client, name: &str, namespace: &str) -> Result<Service, Error> {
+pub async fn service_deploy(
+    client: Client,
+    name: &str,
+    namespace: &str,
+    port: i32,
+) -> Result<Service, Error> {
     // Definition of the service
-    let s: Service = service_create(name, namespace);
+    let s: Service = service_create(name, namespace, port);
     trace!("{:#?}", s);
 
     // Create the deployment defined above
@@ -61,12 +66,12 @@ pub async fn service_undeploy(client: Client, name: &str, namespace: &str) -> Re
 
 /// Service: Generate
 pub fn service_generate() {
-    let data = serde_yaml::to_string(&service_create("postgresql", "default"))
+    let data = serde_yaml::to_string(&service_create("postgresql", "default", 5432))
         .expect("Can't serialize pgopr-service.yaml");
     fs::write("pgopr-service.yaml", data).expect("Unable to write file: pgopr-service.yaml");
 }
 
-fn service_create(name: &str, namespace: &str) -> Service {
+fn service_create(name: &str, namespace: &str, port: i32) -> Service {
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
     labels.insert("app".to_owned(), name.to_owned());
 
@@ -80,7 +85,7 @@ fn service_create(name: &str, namespace: &str) -> Service {
         spec: Some(ServiceSpec {
             type_: Some("NodePort".to_owned()),
             ports: Some(vec![ServicePort {
-                port: 5432,
+                port,
                 ..ServicePort::default()
             }]),
             selector: Some(labels.clone()),


### PR DESCRIPTION
## Summary

Add `pgopr provision pgexporter` and `pgopr retire pgexporter`
commands, plus YAML generation via `pgopr generate -t pgexporter`.

## Design

pgexporter is a stateless Prometheus metrics exporter that connects
to the PostgreSQL primary. The implementation follows the same pattern
as the existing primary and replica provisioning:

- **Deployment** with the `pgexporter-rocky10` image
- **Service** exposing port 5002 (metrics endpoint)
- **No PersistentVolume** — pgexporter is stateless
- **Env vars:** `PG_PRIMARY_NAME`, `PG_PRIMARY_PORT`,
  `PG_EXPORTER_NAME`, `PG_EXPORTER_PASSWORD`

## Service port fix

The service helper previously hardcoded port 5432. This change adds
a port parameter so each component uses its correct port:
- Primary / Replica: 5432
- pgexporter: 5002

## Files changed

| File | Change |
|------|--------|
| `src/pgexporter.rs` | New — deploy/undeploy/generate/create |
| `src/main.rs` | Add module, CLI subcommands, handler dispatch |
| `src/handlers/cluster.rs` | Add provision/retire handlers |
| `src/handlers/generate.rs` | Add pgexporter generation |
| `src/services.rs` | Add port parameter to service_deploy/service_create |

## Prerequisite

The `pgexporter-rocky10` container image is being added in
pgopr/pgopr-images#25. The image must be available in the cluster
before provisioning.

## PostgreSQL setup

The pgexporter user requires `pg_monitor` on the primary:

```sql
CREATE ROLE pgexporter WITH LOGIN PASSWORD 'pgexporter';
GRANT pg_monitor TO pgexporter;
```

This role setup is not yet automated by the operator and must be
done manually on the primary. Automating it (via ConfigMap or init
script) is a follow-up.

Fixes #36