### PR TITLE
[#48] Move reconciliation toward CRD-driven operator model

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Nick Boyadjian <nboyadjian95@gmail.com>
 Bhawesh Panwar <panwarbhawesh1112@gmail.com>
 Sakshii-27 <sakshiaggarwal2706@gmail.com>
 Frank Heikens <frank@elevarq.com>
+Amr Shams     <amr.shams2015.as@gmail.com>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ description = "PostgreSQL operator for Kubernetes"
 [dependencies]
 tokio = { version = "1.49", features = ["full"] }
 kube = { version = "3.0", default-features = true, features = ["client", "derive", "runtime"] }
-k8s-openapi = { version = "0.27", default-features = true, features = ["v1_35"] }
+k8s-openapi = { version = "0.27", default-features = true, features = ["v1_35", "schemars"] }
 clap = { version = "4.5", default-features = false, features = ["std", "cargo", "help"] }
 clap_complete = { version = "4.5" }
 directories = { version = "6.0" }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,0 +1,328 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS of THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+use crate::crd::v1::{PgOprStatus, pgopr};
+use crate::manager::ResourceManager;
+use crate::{Error, persistent, primary, replica, services};
+use k8s_openapi::api::apps::v1::Deployment;
+use k8s_openapi::api::core::v1::{PersistentVolume, PersistentVolumeClaim, Pod, Service};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, Time};
+use kube::{Api, Client, ResourceExt, api::ListParams};
+use std::sync::Arc;
+
+/// Cluster represents the desired state of a PostgreSQL Star Configuration
+pub struct Cluster {
+    manager: ResourceManager,
+}
+
+impl Cluster {
+    pub fn new(client: Client) -> Self {
+        Self {
+            manager: ResourceManager::new(client),
+        }
+    }
+
+    /// Observes the actual state of the cluster and returns a status object
+    pub async fn observe(&self, pgopr: &pgopr) -> Result<PgOprStatus, Error> {
+        let name = pgopr.name_any();
+        let namespace = pgopr.namespace().unwrap_or_else(|| "default".to_string());
+        let deploy_api: Api<Deployment> = Api::namespaced(self.manager.get_client(), &namespace);
+
+        let mut status = PgOprStatus {
+            phase: "Pending".to_string(),
+            ..Default::default()
+        };
+        let mut failure_reason: Option<String> = self.pod_failure_reason(&namespace, &name).await?;
+
+        if let Ok(primary) = deploy_api.get(&name).await
+            && let Some(s) = primary.status
+        {
+            status.primary_ready = s.ready_replicas.unwrap_or(0) > 0;
+        }
+
+        let replicas_spec = pgopr.spec.replicas.unwrap_or(0);
+        let mut ready_count = 0;
+        for i in 1..=replicas_spec {
+            let replica_name = format!("{}-replica-{}", name, i);
+            if failure_reason.is_none() {
+                failure_reason = self.pod_failure_reason(&namespace, &replica_name).await?;
+            }
+            if let Ok(replica) = deploy_api.get(&replica_name).await
+                && let Some(s) = replica.status
+                && s.ready_replicas.unwrap_or(0) > 0
+            {
+                ready_count += 1;
+            }
+        }
+        status.ready_replicas = ready_count as u32;
+
+        if let Some(reason) = failure_reason {
+            status.phase = "Failed".to_string();
+            status.conditions = Some(vec![condition(
+                pgopr,
+                "Ready",
+                "False",
+                "PodFailure",
+                format!("A PostgreSQL pod is not ready: {}", reason),
+            )]);
+        } else if status.primary_ready && status.ready_replicas == replicas_spec {
+            status.phase = "Running".to_string();
+            status.conditions = Some(vec![condition(
+                pgopr,
+                "Ready",
+                "True",
+                "ClusterReady",
+                "All PostgreSQL deployments are ready".to_string(),
+            )]);
+        } else if status.primary_ready {
+            status.phase = "Degraded".to_string();
+            status.conditions = Some(vec![condition(
+                pgopr,
+                "Ready",
+                "False",
+                "ReplicasNotReady",
+                "Primary is ready but one or more replicas are not ready".to_string(),
+            )]);
+        } else {
+            status.conditions = Some(vec![condition(
+                pgopr,
+                "Ready",
+                "False",
+                "PrimaryNotReady",
+                "Primary deployment is not ready".to_string(),
+            )]);
+        }
+
+        Ok(status)
+    }
+
+    /// Gets the first waiting reason for pods that belong to a deployment.
+    ///
+    /// # Arguments
+    /// - `namespace` - Namespace where the pods reside.
+    /// - `app` - Value of the app label used by the deployment.
+    async fn pod_failure_reason(
+        &self,
+        namespace: &str,
+        app: &str,
+    ) -> Result<Option<String>, Error> {
+        let pod_api: Api<Pod> = Api::namespaced(self.manager.get_client(), namespace);
+
+        let selector = format!("app={app}");
+
+        let pods = pod_api
+            .list(&ListParams::default().labels(&selector))
+            .await?;
+
+        for pod in pods {
+            if let Some(status) = pod.status {
+                let mut all_statuses = Vec::new();
+
+                if let Some(container_statuses) = status.container_statuses {
+                    all_statuses.extend(container_statuses);
+                }
+
+                if let Some(init_container_statuses) = status.init_container_statuses {
+                    all_statuses.extend(init_container_statuses);
+                }
+
+                for container_status in all_statuses {
+                    if let Some(state) = container_status.state {
+                        let reason = if let Some(waiting) = state.waiting {
+                            waiting.reason
+                        } else if let Some(terminated) = state.terminated {
+                            terminated.reason
+                        } else {
+                            None
+                        };
+
+                        if let Some(reason) = reason
+                            && is_failure_reason(&reason)
+                        {
+                            return Ok(Some(reason));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Ensures all resources for the cluster exist and match the spec.
+    ///
+    /// # Arguments
+    /// - `pgopr` - The PgOpr resource that defines the desired cluster state.
+    pub async fn sync(&self, pgopr: Arc<pgopr>) -> Result<(), Error> {
+        let name = pgopr.name_any();
+        let namespace = pgopr.namespace().unwrap_or_else(|| "default".to_string());
+        let storage = pgopr.spec.storage;
+        let replicas = pgopr.spec.replicas.unwrap_or(0);
+
+        let pv_name = format!("{}-pv-volume", name);
+        let pv = persistent::build_pv(&pv_name, storage, &name, "/tmp/kind");
+        self.manager.sync_cluster(pv).await?;
+
+        let pvc_name = format!("{}-pv-claim", name);
+        let pvc = persistent::build_pvc(&pvc_name, &namespace, storage, &name);
+        self.manager.sync(&pgopr, pvc).await?;
+
+        let primary_deploy = primary::build(&name, &namespace);
+        self.manager.sync(&pgopr, primary_deploy).await?;
+
+        let primary_svc = services::build(&name, &namespace);
+        self.manager.sync(&pgopr, primary_svc).await?;
+
+        for i in 1..=replicas {
+            let replica_name = format!("{}-replica-{}", name, i);
+            let slot_name = format!("replica{}", i);
+
+            let replica_pv_name = format!("{}-pv-volume", replica_name);
+            let replica_host_path = format!("/tmp/kind-replica-{}", i);
+            let replica_pv =
+                persistent::build_pv(&replica_pv_name, storage, &replica_name, &replica_host_path);
+            self.manager.sync_cluster(replica_pv).await?;
+
+            let replica_pvc_name = format!("{}-pv-claim", replica_name);
+            let replica_pvc =
+                persistent::build_pvc(&replica_pvc_name, &namespace, storage, &replica_name);
+            self.manager.sync(&pgopr, replica_pvc).await?;
+
+            let replica_deploy = replica::build(&replica_name, &name, &namespace, &slot_name);
+            self.manager.sync(&pgopr, replica_deploy).await?;
+
+            let replica_svc = services::build(&replica_name, &namespace);
+            self.manager.sync(&pgopr, replica_svc).await?;
+        }
+
+        self.cleanup_stale_replicas(&name, &namespace, replicas)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Removes replica resources whose ordinal is greater than the desired replica count.
+    ///
+    /// # Arguments
+    /// - `name` - Name of the PgOpr resource.
+    /// - `namespace` - Namespace where the replica resources reside.
+    /// - `desired_replicas` - Desired number of replicas.
+    pub async fn cleanup_stale_replicas(
+        &self,
+        name: &str,
+        namespace: &str,
+        desired_replicas: u32,
+    ) -> Result<(), Error> {
+        let deploy_api: Api<Deployment> = Api::namespaced(self.manager.get_client(), namespace);
+        for deployment in deploy_api.list(&ListParams::default()).await? {
+            let resource_name = deployment.name_any();
+            if replica_ordinal(name, &resource_name).is_some_and(|i| i > desired_replicas) {
+                self.delete_replica_stack(&resource_name, namespace).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Deletes all resources that belong to the given cluster, including managed PVs.
+    ///
+    /// # Arguments
+    /// - `pgopr` - The PgOpr resource that defines the cluster to clean.
+    pub async fn cleanup_all(&self, pgopr: &pgopr) -> Result<(), Error> {
+        let name = pgopr.name_any();
+        let namespace = pgopr.namespace().unwrap_or_else(|| "default".to_string());
+
+        let deploy_api: Api<Deployment> = Api::namespaced(self.manager.get_client(), &namespace);
+        for deployment in deploy_api.list(&ListParams::default()).await? {
+            let resource_name = deployment.name_any();
+            if replica_ordinal(&name, &resource_name).is_some() {
+                self.delete_replica_stack(&resource_name, &namespace)
+                    .await?;
+            }
+        }
+
+        self.manager.delete::<Service>(&name, &namespace).await?;
+        self.manager.delete::<Deployment>(&name, &namespace).await?;
+        self.manager
+            .delete::<PersistentVolumeClaim>(&format!("{}-pv-claim", name), &namespace)
+            .await?;
+        self.manager
+            .delete_cluster::<PersistentVolume>(&format!("{}-pv-volume", name))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn delete_replica_stack(&self, replica_name: &str, namespace: &str) -> Result<(), Error> {
+        self.manager
+            .delete::<Service>(replica_name, namespace)
+            .await?;
+        self.manager
+            .delete::<Deployment>(replica_name, namespace)
+            .await?;
+        self.manager
+            .delete::<PersistentVolumeClaim>(&format!("{}-pv-claim", replica_name), namespace)
+            .await?;
+        self.manager
+            .delete_cluster::<PersistentVolume>(&format!("{}-pv-volume", replica_name))
+            .await?;
+
+        Ok(())
+    }
+}
+
+fn replica_ordinal(cluster_name: &str, resource_name: &str) -> Option<u32> {
+    let prefix = format!("{}-replica-", cluster_name);
+    resource_name
+        .strip_prefix(&prefix)
+        .and_then(|suffix| suffix.split('-').next())
+        .and_then(|ordinal| ordinal.parse::<u32>().ok())
+}
+
+fn condition(pgopr: &pgopr, type_: &str, status: &str, reason: &str, message: String) -> Condition {
+    let last_transition_time = pgopr
+        .status
+        .as_ref()
+        .and_then(|status| status.conditions.as_ref())
+        .and_then(|conditions| {
+            conditions
+                .iter()
+                .find(|condition| condition.type_ == type_)
+                .and_then(|condition| {
+                    if condition.status == status && condition.reason == reason {
+                        Some(condition.last_transition_time.clone())
+                    } else {
+                        None
+                    }
+                })
+        })
+        .unwrap_or_else(|| Time(k8s_openapi::jiff::Timestamp::now()));
+
+    Condition {
+        type_: type_.to_string(),
+        status: status.to_string(),
+        observed_generation: None,
+        last_transition_time,
+        reason: reason.to_string(),
+        message,
+    }
+}
+
+fn is_failure_reason(reason: &str) -> bool {
+    matches!(
+        reason,
+        "CrashLoopBackOff"
+            | "ErrImagePull"
+            | "ImagePullBackOff"
+            | "CreateContainerConfigError"
+            | "CreateContainerError"
+            | "InvalidImageName"
+            | "Error"
+            | "OOMKilled"
+    )
+}

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -6,10 +6,11 @@
  *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
  */
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 use kube::CustomResource;
 use kube::{
     Api, Client, Error,
-    api::{DeleteParams, PostParams},
+    api::{DeleteParams, Patch, PatchParams, PostParams},
     core::crd::CustomResourceExt,
     runtime::wait::{await_condition, conditions},
 };
@@ -24,12 +25,12 @@ pub mod v1 {
     /// The CustomDefinitionResource for the operator
     #[derive(CustomResource, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
     #[kube(
-        // apiextensions = "v1",
         group = "pgopr.io",
         version = "v1",
         kind = "pgopr",
         plural = "pgoprs",
         derive = "PartialEq",
+        status = "PgOprStatus",
         namespaced
     )]
     pub struct PgOprSpec {
@@ -37,6 +38,19 @@ pub mod v1 {
         pub storage: u32,
         /// Number of replicas in the star configuration
         pub replicas: Option<u32>,
+    }
+
+    /// The status of the PgOpr resource
+    #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema, Default)]
+    pub struct PgOprStatus {
+        /// Whether the primary is ready
+        pub primary_ready: bool,
+        /// Number of ready replicas
+        pub ready_replicas: u32,
+        /// Current phase (e.g., Pending, Running, Failed)
+        pub phase: String,
+        /// List of conditions for the resource
+        pub conditions: Option<Vec<Condition>>,
     }
 
     /// The general settings
@@ -49,27 +63,34 @@ pub mod v1 {
     }
 }
 
-/// Create the CustomResoureDefinition object
+/// Create or update the CustomResourceDefinition object
 ///
 /// # Arguments
 /// - `client` - The Kubernetes client
-///
-/// Note: It is assumed the resource does not already exists for simplicity. Returns an `Error` if it does.
 pub async fn crd_deploy(client: Client) -> Result<CustomResourceDefinition, Error> {
     let crd: CustomResourceDefinition = v1::pgopr::crd();
     trace!("{:#?}", crd);
 
-    // Create the object
     let crd_api: Api<CustomResourceDefinition> = Api::all(client.clone());
     let result: Result<CustomResourceDefinition, Error> =
-        crd_api.create(&PostParams::default(), &crd).await;
+        match crd_api.create(&PostParams::default(), &crd).await {
+            Ok(crd) => {
+                info!("Created CRD");
+                Ok(crd)
+            }
+            Err(Error::Api(err)) if err.code == 409 => {
+                let patch = Patch::Merge(&crd);
+                let crd = crd_api
+                    .patch("pgoprs.pgopr.io", &PatchParams::default(), &patch)
+                    .await?;
+                info!("Updated CRD");
+                Ok(crd)
+            }
+            Err(err) => Err(err),
+        };
 
     let establish = await_condition(crd_api, "pgoprs.pgopr.io", conditions::is_crd_established());
     let _ = tokio::time::timeout(std::time::Duration::from_secs(10), establish).await;
-
-    if result.is_ok() {
-        info!("Created CRD");
-    }
 
     result
 }

--- a/src/handlers/cluster.rs
+++ b/src/handlers/cluster.rs
@@ -5,120 +5,175 @@
  *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
  *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
  */
-use crate::{crd, k8s, persistent, primary, services};
-use kube::Client;
-use log::debug;
+use crate::crd::v1::PgOprSpec;
+use crate::crd::v1::pgopr;
+use crate::k8s;
+use kube::{
+    Api, Client,
+    api::{DeleteParams, Patch, PatchParams, PostParams},
+};
+use log::error;
+
+const DEFAULT_CLUSTER_NAME: &str = "postgresql";
+const DEFAULT_NAMESPACE: &str = "default";
+const DEFAULT_STORAGE_GI: u32 = 5;
 
 /// Orchestrates the installation of the operator and its CRDs.
 pub async fn handle_install() {
     super::print_header();
     let client: Client = k8s::k8s_client().await;
-    let _ = crd::crd_deploy(client).await;
+    let _ = crate::crd::crd_deploy(client).await;
 }
 
 /// Orchestrates the uninstallation of the operator and its CRDs.
 pub async fn handle_uninstall() {
     super::print_header();
     let client: Client = k8s::k8s_client().await;
-    let _ = crd::crd_undeploy(client).await;
+    let _ = crate::crd::crd_undeploy(client).await;
 }
 
-/// Provisions the primary database components (PV, PVC, Deployment, Service).
+/// Creates the PgOpr resource.
+///
+/// # Arguments
+/// - `client` - Kubernetes client to create the PgOpr resource with.
+/// - `name` - Name of the PgOpr resource to create.
+/// - `namespace` - Namespace where the PgOpr resource resides.
+/// - `replicas` - Desired number of replicas.
+async fn create_cluster(
+    client: Client,
+    name: &str,
+    namespace: &str,
+    replicas: u32,
+) -> Result<pgopr, crate::Error> {
+    let api: Api<pgopr> = Api::namespaced(client, namespace);
+    let mut cluster = pgopr::new(
+        name,
+        PgOprSpec {
+            storage: DEFAULT_STORAGE_GI,
+            replicas: Some(replicas),
+        },
+    );
+    cluster.metadata.namespace = Some(namespace.to_string());
+
+    api.create(&PostParams::default(), &cluster)
+        .await
+        .map_err(crate::Error::from)
+}
+
+/// Updates the replica count on an existing PgOpr resource.
+///
+/// # Arguments
+/// - `client` - Kubernetes client to modify the PgOpr resource with.
+/// - `name` - Name of the PgOpr resource to modify.
+/// - `namespace` - Namespace where the PgOpr resource resides.
+/// - `replicas` - Desired number of replicas.
+async fn patch_replicas(
+    client: Client,
+    name: &str,
+    namespace: &str,
+    replicas: u32,
+) -> Result<pgopr, crate::Error> {
+    let api: Api<pgopr> = Api::namespaced(client, namespace);
+    let patch = serde_json::json!({
+        "spec": {
+            "replicas": replicas
+        }
+    });
+
+    api.patch(name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await
+        .map_err(crate::Error::from)
+}
+
+/// Gets the PgOpr resource.
+///
+/// # Arguments
+/// - `client` - Kubernetes client to get the PgOpr resource with.
+/// - `name` - Name of the PgOpr resource to get.
+/// - `namespace` - Namespace where the PgOpr resource resides.
+async fn get_cluster(client: Client, name: &str, namespace: &str) -> Result<pgopr, crate::Error> {
+    let api: Api<pgopr> = Api::namespaced(client, namespace);
+    api.get(name).await.map_err(crate::Error::from)
+}
+
+/// Provisions the primary database components through a PgOpr resource.
 pub async fn handle_provision_primary() {
     super::print_header();
-    debug!("primary");
     let client: Client = k8s::k8s_client().await;
-    let namespace = "default".to_owned();
-
-    let _pv = persistent::persistent_volume_deploy(
-        client.clone(),
-        "postgresql-pv-volume",
-        5u32,
-        "postgresql",
-        "/tmp/kind",
-    )
-    .await;
-    let _pvc = persistent::persistent_volume_claim_deploy(
-        client.clone(),
-        "postgresql-pv-claim",
-        &namespace,
-        5u32,
-        "postgresql",
-    )
-    .await;
-    let _d = primary::primary_deploy(client.clone(), "postgresql", &namespace).await;
-    let _s = services::service_deploy(client.clone(), "postgresql", &namespace).await;
+    match get_cluster(client.clone(), DEFAULT_CLUSTER_NAME, DEFAULT_NAMESPACE).await {
+        Ok(_) => {}
+        Err(crate::Error::KubeError { source }) => match source {
+            kube::Error::Api(err) if err.code == 404 => {
+                if let Err(err) =
+                    create_cluster(client, DEFAULT_CLUSTER_NAME, DEFAULT_NAMESPACE, 0).await
+                {
+                    error!("Unable to create PgOpr resource: {:?}", err);
+                }
+            }
+            err => error!("Unable to get PgOpr resource: {:?}", err),
+        },
+        Err(err) => error!("Unable to get PgOpr resource: {:?}", err),
+    }
 }
 
-/// Removes the primary database components.
+/// Removes the primary database components through the PgOpr resource.
 pub async fn handle_retire_primary() {
     super::print_header();
-    debug!("primary");
     let client: Client = k8s::k8s_client().await;
-    let namespace = "default".to_owned();
+    let api: Api<pgopr> = Api::namespaced(client, DEFAULT_NAMESPACE);
 
-    let _s = services::service_undeploy(client.clone(), "postgresql", &namespace).await;
-    let _d = primary::primary_undeploy(client.clone(), "postgresql", &namespace).await;
-    let _pvc = persistent::persistent_volume_claim_undeploy(
-        client.clone(),
-        "postgresql-pv-claim",
-        &namespace,
-    )
-    .await;
-    let _pv = persistent::persistent_volume_undeploy(client.clone(), "postgresql-pv-volume").await;
+    match api
+        .delete(DEFAULT_CLUSTER_NAME, &DeleteParams::default())
+        .await
+    {
+        Ok(_) => {}
+        Err(kube::Error::Api(err)) if err.code == 404 => {}
+        Err(err) => {
+            error!("Unable to delete PgOpr resource: {:?}", err);
+        }
+    }
 }
 
-/// Provisions the replica database components (PV, PVC, Deployment, Service).
+/// Provisions the replica database components through a PgOpr resource.
 pub async fn handle_provision_replica() {
     super::print_header();
-    debug!("replica");
     let client: Client = k8s::k8s_client().await;
-    let namespace = "default".to_owned();
-
-    let _pv = persistent::persistent_volume_deploy(
-        client.clone(),
-        "postgresql-replica-pv-volume",
-        5u32,
-        "postgresql-replica",
-        "/tmp/kind-replica",
-    )
-    .await;
-    let _pvc = persistent::persistent_volume_claim_deploy(
-        client.clone(),
-        "postgresql-replica-pv-claim",
-        &namespace,
-        5u32,
-        "postgresql-replica",
-    )
-    .await;
-    let _d = crate::replica::replica_deploy(
-        client.clone(),
-        "postgresql-replica",
-        "postgresql",
-        &namespace,
-        "replica1",
-    )
-    .await;
-    let _s = services::service_deploy(client.clone(), "postgresql-replica", &namespace).await;
+    match get_cluster(client.clone(), DEFAULT_CLUSTER_NAME, DEFAULT_NAMESPACE).await {
+        Ok(current) => {
+            let replicas = current.spec.replicas.unwrap_or(0) + 1;
+            if let Err(err) =
+                patch_replicas(client, DEFAULT_CLUSTER_NAME, DEFAULT_NAMESPACE, replicas).await
+            {
+                error!("Unable to patch PgOpr replicas: {:?}", err);
+            }
+        }
+        Err(crate::Error::KubeError { source }) => match source {
+            kube::Error::Api(err) if err.code == 404 => {
+                if let Err(err) =
+                    create_cluster(client, DEFAULT_CLUSTER_NAME, DEFAULT_NAMESPACE, 1).await
+                {
+                    error!("Unable to create PgOpr resource: {:?}", err);
+                }
+            }
+            err => error!("Unable to get PgOpr resource: {:?}", err),
+        },
+        Err(err) => error!("Unable to get PgOpr resource: {:?}", err),
+    }
 }
 
-/// Removes the replica database components.
+/// Removes the replica database components through a PgOpr resource.
 pub async fn handle_retire_replica() {
     super::print_header();
-    debug!("replica");
     let client: Client = k8s::k8s_client().await;
-    let namespace = "default".to_owned();
-
-    let _s = services::service_undeploy(client.clone(), "postgresql-replica", &namespace).await;
-    let _d =
-        crate::replica::replica_undeploy(client.clone(), "postgresql-replica", &namespace).await;
-    let _pvc = persistent::persistent_volume_claim_undeploy(
-        client.clone(),
-        "postgresql-replica-pv-claim",
-        &namespace,
-    )
-    .await;
-    let _pv =
-        persistent::persistent_volume_undeploy(client.clone(), "postgresql-replica-pv-volume")
-            .await;
+    match get_cluster(client.clone(), DEFAULT_CLUSTER_NAME, DEFAULT_NAMESPACE).await {
+        Ok(current) => {
+            let replicas = current.spec.replicas.unwrap_or(0).saturating_sub(1);
+            if let Err(err) =
+                patch_replicas(client, DEFAULT_CLUSTER_NAME, DEFAULT_NAMESPACE, replicas).await
+            {
+                error!("Unable to patch PgOpr replicas: {:?}", err);
+            }
+        }
+        Err(err) => error!("Unable to get PgOpr resource: {:?}", err),
+    }
 }

--- a/src/handlers/generate.rs
+++ b/src/handlers/generate.rs
@@ -6,8 +6,9 @@
  *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
  */
 
-use crate::{crd, persistent, primary, services};
+use crate::{crd, persistent, primary, replica, services};
 use clap::ArgMatches;
+use std::fs;
 
 /// Handles the 'generate' subcommand logic for various resource types.
 ///
@@ -19,16 +20,31 @@ pub fn handle_generate(sub_matches: &ArgMatches) {
             crd::crd_generate();
         }
         "service" => {
-            services::service_generate();
+            let s = services::build("postgresql", "default");
+            let data = serde_yaml::to_string(&s).expect("Can't serialize pgopr-service.yaml");
+            fs::write("pgopr-service.yaml", data)
+                .expect("Unable to write file: pgopr-service.yaml");
         }
         "persistent" => {
-            persistent::persistent_generate();
+            let pv = persistent::build_pv("postgresql-pv-volume", 5, "postgresql", "/tmp/kind");
+            let data = serde_yaml::to_string(&pv).expect("Can't serialize pgopr-pv.yaml");
+            fs::write("pgopr-pv.yaml", data).expect("Unable to write file: pgopr-pv.yaml");
+
+            let pvc = persistent::build_pvc("postgresql-pv-claim", "default", 5, "postgresql");
+            let data = serde_yaml::to_string(&pvc).expect("Can't serialize pgopr-pvc.yaml");
+            fs::write("pgopr-pvc.yaml", data).expect("Unable to write file: pgopr-pvc.yaml");
         }
         "primary" => {
-            primary::primary_generate();
+            let p = primary::build("postgresql", "default");
+            let data = serde_yaml::to_string(&p).expect("Can't serialize pgopr-primary.yaml");
+            fs::write("pgopr-primary.yaml", data)
+                .expect("Unable to write file: pgopr-primary.yaml");
         }
         "replica" => {
-            crate::replica::replica_generate();
+            let r = replica::build("postgresql-replica", "postgresql", "default", "replica1");
+            let data = serde_yaml::to_string(&r).expect("Can't serialize pgopr-replica.yaml");
+            fs::write("pgopr-replica.yaml", data)
+                .expect("Unable to write file: pgopr-replica.yaml");
         }
         name => {
             unreachable!("Unsupported type `{}`", name)

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@
  */
 use clap::{Arg, Command, crate_description, crate_name, crate_version, value_parser};
 use clap_complete::{Generator, Shell, generate};
-use kube::{Resource, ResourceExt, client::Client, runtime::controller::Action};
+use kube::{Api, Resource, ResourceExt, client::Client, runtime::controller::Action};
 use log::LevelFilter;
 use log4rs::{
     append::console::{ConsoleAppender, Target},
@@ -18,10 +18,12 @@ use tokio::time::Duration;
 
 use crate::crd::v1::pgopr;
 
+mod cluster;
 pub mod crd;
 mod finalizer;
 pub mod handlers;
 mod k8s;
+mod manager;
 mod persistent;
 mod primary;
 mod replica;
@@ -34,23 +36,9 @@ pub(crate) struct ContextData {
 }
 
 impl ContextData {
-    /// Constructs a new instance of ContextData
-    ///
-    /// # Arguments:
-    /// - `client`: Kubernetes client
     pub fn new(client: Client) -> Self {
         ContextData { client }
     }
-}
-
-/// Action to be taken upon a `pgopr` resource during reconciliation
-enum PgOprAction {
-    /// Create the primary subresources
-    CreatePrimary,
-    /// Delete all primary subresources
-    DeletePrimary,
-    /// This `PgOpr` resource is in desired state and requires no actions to be taken
-    NoOp,
 }
 
 /// Initialize the logging frameworks
@@ -218,80 +206,48 @@ async fn main() {
 ///
 async fn reconcile(pgopr: Arc<pgopr>, context: Arc<ContextData>) -> Result<Action, Error> {
     let client: Client = context.client.clone();
-    let namespace: String = match pgopr.namespace() {
-        None => {
-            return Err(Error::UserInputError(
-                "Expected pgopr resource to be namespaced. Can't deploy to an unknown namespace."
-                    .to_owned(),
-            ));
-        }
+    let cluster = crate::cluster::Cluster::new(client.clone());
+    let namespace = pgopr.namespace().unwrap_or("default".into());
+    let name = pgopr.name_any();
 
-        Some(namespace) => namespace,
-    };
-
-    // Performs action as decided by the `determine_action` function.
-    match determine_action(&pgopr) {
-        PgOprAction::CreatePrimary => {
-            let name = pgopr.name_any();
-            let replicas = pgopr.spec.replicas.unwrap_or(0);
-
-            finalizer::add(client.clone(), &name, &namespace).await?;
-            primary::primary_deploy(client.clone(), &name, &namespace).await?;
-
-            for i in 1..=replicas {
-                let replica_name = format!("{}-replica-{}", name, i);
-                let slot_name = format!("replica{}", i);
-                crate::replica::replica_deploy(
-                    client.clone(),
-                    &replica_name,
-                    &name,
-                    &namespace,
-                    &slot_name,
-                )
-                .await?;
-            }
-
-            Ok(Action::requeue(Duration::from_secs(10)))
-        }
-
-        PgOprAction::DeletePrimary => {
-            let name = pgopr.name_any();
-            let replicas = pgopr.spec.replicas.unwrap_or(0);
-
-            for i in 1..=replicas {
-                let replica_name = format!("{}-replica-{}", name, i);
-                crate::replica::replica_undeploy(client.clone(), &replica_name, &namespace).await?;
-            }
-            primary::primary_undeploy(client.clone(), &name, &namespace).await?;
-            finalizer::delete(client, &name, &namespace).await?;
-
-            Ok(Action::await_change())
-        }
-
-        PgOprAction::NoOp => Ok(Action::requeue(Duration::from_secs(10))),
-    }
-}
-
-/// Determine the action
-///
-/// # Arguments
-/// - `pgopr`: A reference to `pgopr` being reconciled to decide next action upon
-///
-fn determine_action(pgopr: &pgopr) -> PgOprAction {
     if pgopr.meta().deletion_timestamp.is_some() {
-        PgOprAction::DeletePrimary
-    } else if pgopr
+        cluster.cleanup_all(&pgopr).await?;
+        finalizer::delete(client, &name, &namespace).await?;
+        return Ok(Action::await_change());
+    }
+
+    if pgopr
         .meta()
         .finalizers
         .as_ref()
         .is_none_or(|finalizers| finalizers.is_empty())
     {
-        PgOprAction::CreatePrimary
-    } else {
-        PgOprAction::NoOp
+        finalizer::add(client.clone(), &name, &namespace).await?;
     }
-}
 
+    // sync with the cluster manager
+    cluster.sync(pgopr.clone()).await?;
+
+    // get the status
+    let status = cluster.observe(&pgopr).await?;
+
+    // patch the new status
+    let pgopr_api: Api<pgopr> = Api::namespaced(client, &namespace);
+    let ps = kube::api::PatchParams::apply("pgopr-manager");
+    let _ = pgopr_api
+        .patch_status(
+            &pgopr.name_any(),
+            &ps,
+            &kube::api::Patch::Apply(serde_json::json!({
+                "apiVersion": "pgopr.io/v1",
+                "kind": "pgopr",
+                "status": status
+            })),
+        )
+        .await?;
+
+    Ok(Action::requeue(Duration::from_secs(30)))
+}
 /// The on_error callback
 ///
 /// # Arguments

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,0 +1,130 @@
+/*
+ * Eclipse Public License - v 2.0
+ *
+ *   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+ *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+ *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ */
+
+use crate::Error;
+use crate::crd::v1::pgopr;
+use kube::core::{ClusterResourceScope, NamespaceResourceScope};
+use kube::{
+    Api, Client, Resource,
+    api::{DeleteParams, Patch, PatchParams, ResourceExt},
+};
+use log::info;
+use serde::{Serialize, de::DeserializeOwned};
+use std::fmt::Debug;
+
+/// Global Constants for the Operator
+pub const MANAGER_NAME: &str = "pgopr-manager";
+pub const DEFAULT_NAMESPACE: &str = "default";
+
+/// ResourceManager handles Kubernetes API writes for managed resources.
+pub struct ResourceManager {
+    client: Client,
+}
+
+impl ResourceManager {
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+
+    pub fn get_client(&self) -> Client {
+        self.client.clone()
+    }
+
+    /// Syncs a namespaced Kubernetes resource using Server-Side Apply.
+    ///
+    /// # Arguments
+    /// - `owner` - The PgOpr resource that owns the Kubernetes resource.
+    /// - `resource` - The Kubernetes resource to sync.
+    pub async fn sync<K>(&self, owner: &pgopr, mut resource: K) -> Result<K, Error>
+    where
+        K: Resource<Scope = NamespaceResourceScope> + Clone + Debug + Serialize + DeserializeOwned,
+        K::DynamicType: Default,
+    {
+        let name = resource.name_any();
+        let namespace = resource
+            .namespace()
+            .unwrap_or_else(|| DEFAULT_NAMESPACE.to_string());
+
+        if let Some(owner_ref) = owner.controller_owner_ref(&()) {
+            resource.meta_mut().owner_references = Some(vec![owner_ref]);
+        }
+
+        let api: Api<K> = Api::namespaced(self.client.clone(), &namespace);
+        let params = PatchParams::apply(MANAGER_NAME);
+
+        info!(
+            "Syncing {} resource: {}/{}",
+            K::kind(&Default::default()),
+            namespace,
+            name
+        );
+
+        api.patch(&name, &params, &Patch::Apply(&resource))
+            .await
+            .map_err(Error::from)
+    }
+
+    /// Syncs a cluster-scoped resource using Server-Side Apply.
+    ///
+    /// # Arguments
+    /// - `resource` - The Kubernetes resource to sync.
+    pub async fn sync_cluster<K>(&self, resource: K) -> Result<K, Error>
+    where
+        K: Resource<Scope = ClusterResourceScope> + Clone + Debug + Serialize + DeserializeOwned,
+        K::DynamicType: Default,
+    {
+        let name = resource.name_any();
+        let api: Api<K> = Api::all(self.client.clone());
+        let params = PatchParams::apply(MANAGER_NAME);
+
+        info!(
+            "Syncing {} resource: {}",
+            K::kind(&Default::default()),
+            name
+        );
+
+        api.patch(&name, &params, &Patch::Apply(&resource))
+            .await
+            .map_err(Error::from)
+    }
+
+    /// Deletes a namespaced resource, treating an already-deleted resource as success.
+    ///
+    /// # Arguments
+    /// - `name` - Name of the Kubernetes resource to delete.
+    /// - `namespace` - Namespace where the Kubernetes resource resides.
+    pub async fn delete<K>(&self, name: &str, namespace: &str) -> Result<(), Error>
+    where
+        K: Resource<Scope = NamespaceResourceScope> + Clone + Debug + Serialize + DeserializeOwned,
+        K::DynamicType: Default,
+    {
+        let api: Api<K> = Api::namespaced(self.client.clone(), namespace);
+        match api.delete(name, &DeleteParams::default()).await {
+            Ok(_) => Ok(()),
+            Err(kube::Error::Api(err)) if err.code == 404 => Ok(()),
+            Err(err) => Err(Error::from(err)),
+        }
+    }
+
+    /// Deletes a cluster-scoped resource, treating an already-deleted resource as success.
+    ///
+    /// # Arguments
+    /// - `name` - Name of the Kubernetes resource to delete.
+    pub async fn delete_cluster<K>(&self, name: &str) -> Result<(), Error>
+    where
+        K: Resource<Scope = ClusterResourceScope> + Clone + Debug + Serialize + DeserializeOwned,
+        K::DynamicType: Default,
+    {
+        let api: Api<K> = Api::all(self.client.clone());
+        match api.delete(name, &DeleteParams::default()).await {
+            Ok(_) => Ok(()),
+            Err(kube::Error::Api(err)) if err.code == 404 => Ok(()),
+            Err(err) => Err(Error::from(err)),
+        }
+    }
+}

--- a/src/persistent.rs
+++ b/src/persistent.rs
@@ -5,183 +5,26 @@
  *   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
  *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
  */
+use k8s_openapi::api::core::v1::{HostPathVolumeSource, PersistentVolume, PersistentVolumeSpec};
 use k8s_openapi::{
-    api::core::v1::{
-        HostPathVolumeSource, PersistentVolume, PersistentVolumeClaim, PersistentVolumeClaimSpec,
-        PersistentVolumeSpec, VolumeResourceRequirements,
-    },
+    api::core::v1::{PersistentVolumeClaim, PersistentVolumeClaimSpec, VolumeResourceRequirements},
     apimachinery::pkg::api::resource::Quantity,
 };
-use kube::{
-    Api, Client, Error,
-    api::{DeleteParams, ObjectMeta, PostParams},
-};
-use log::{info, trace};
+use kube::api::ObjectMeta;
 use std::collections::BTreeMap;
-use std::fs;
 
-/// Creates a persistent volume
+/// Builds a persistent volume claim object
 ///
 /// # Arguments
-/// - `client` - The Kubernetes client
-/// - `name` - The name
-/// - `storage` - The storage size
-///
-/// Note: It is assumed the persistent volume does not already exists for simplicity. Returns an `Error` if it does.
-pub async fn persistent_volume_deploy(
-    client: Client,
-    name: &str,
-    storage: u32,
-    label_app: &str,
-    host_path: &str,
-) -> Result<PersistentVolume, Error> {
-    // Definition of the persistent volume
-    let pv: PersistentVolume = pv_create(name, storage, label_app, host_path);
-    trace!("pv: {:?}", pv);
-
-    // Create the persistent volume defined above
-    let pv_api: Api<PersistentVolume> = Api::all(client);
-    let pp: PostParams = PostParams::default();
-    match pv_api.create(&pp, &pv).await {
-        Ok(o) => {
-            info!("Created PersistentVolume");
-            Ok(o)
-        }
-        Err(e) => Err(e),
-    }
-}
-
-/// Deletes an existing persistent volume
-///
-/// # Arguments:
-/// - `client` - The Kubernetes client
-/// - `name` - The name of the persistent volume
-///
-/// Note: It is assumed the persistence volume exists for simplicity. Otherwise returns an Error.
-pub async fn persistent_volume_undeploy(client: Client, name: &str) -> Result<(), Error> {
-    let api: Api<PersistentVolume> = Api::all(client);
-    match api.delete(name, &DeleteParams::default()).await {
-        Ok(_) => {
-            info!("Deleted PersistentVolume");
-        }
-
-        Err(e) => return Err(e),
-    }
-    Ok(())
-}
-
-/// Creates a persistent volume claim
-///
-/// # Arguments
-/// - `client` - The Kubernetes client
 /// - `name` - The name
 /// - `namespace` - The namespace
 /// - `storage` - The storage size
-///
-/// Note: It is assumed the persistent volume claim does not already exists for simplicity. Returns an `Error` if it does.
-pub async fn persistent_volume_claim_deploy(
-    client: Client,
+pub fn build_pvc(
     name: &str,
     namespace: &str,
     storage: u32,
     label_app: &str,
-) -> Result<PersistentVolumeClaim, Error> {
-    // Definition of the persistent volume claim
-    let pvc: PersistentVolumeClaim = pvc_create(name, namespace, storage, label_app);
-    trace!("pvc: {:?}", pvc);
-
-    // Create the persistent volume claim defined above
-    let pvc_api: Api<PersistentVolumeClaim> = Api::namespaced(client, namespace);
-    let pp: PostParams = PostParams::default();
-    match pvc_api.create(&pp, &pvc).await {
-        Ok(o) => {
-            info!("Created PersistentVolumeClaim");
-            Ok(o)
-        }
-        Err(e) => Err(e),
-    }
-}
-
-/// Deletes an existing persistent volume claim
-///
-/// # Arguments:
-/// - `client` - The Kubernetes client
-/// - `name` - The name of the persistent volume claim
-/// - `namespace` - The namespace
-///
-/// Note: It is assumed the persistence volume claim exists for simplicity. Otherwise returns an Error.
-pub async fn persistent_volume_claim_undeploy(
-    client: Client,
-    name: &str,
-    namespace: &str,
-) -> Result<(), Error> {
-    let api: Api<PersistentVolumeClaim> = Api::namespaced(client, namespace);
-    match api.delete(name, &DeleteParams::default()).await {
-        Ok(_) => {
-            info!("Deleted PersistentVolumeClaim");
-        }
-
-        Err(e) => return Err(e),
-    }
-    Ok(())
-}
-
-/// Persistent: Generate
-pub fn persistent_generate() {
-    let pv = serde_yaml::to_string(&pv_create(
-        "postgresql-pv-volume",
-        5u32,
-        "postgresql",
-        "/tmp/kind",
-    ))
-    .expect("Can't serialize pgopr-pv.yaml");
-    fs::write("pgopr-pv.yaml", pv).expect("Unable to write file: pgopr-pv.yaml");
-
-    let pvc = serde_yaml::to_string(&pvc_create(
-        "postgresql-pv-claim",
-        "default",
-        5u32,
-        "postgresql",
-    ))
-    .expect("Can't serialize pgopr-pvc.yaml");
-    fs::write("pgopr-pvc.yaml", pvc).expect("Unable to write file: pgopr-pvc.yaml");
-}
-
-fn pv_create(name: &str, storage: u32, label_app: &str, host_path: &str) -> PersistentVolume {
-    let mut labels: BTreeMap<String, String> = BTreeMap::new();
-    labels.insert("app".to_owned(), label_app.to_owned());
-    labels.insert("type".to_owned(), "local".to_owned());
-
-    let mut size: String = storage.to_string().to_owned();
-    size.push_str("Gi");
-
-    let mut cap: BTreeMap<String, Quantity> = BTreeMap::new();
-    cap.insert("storage".to_owned(), Quantity(size));
-
-    // Definition of the deployment
-    let pv: PersistentVolume = PersistentVolume {
-        metadata: ObjectMeta {
-            name: Some(name.to_owned()),
-            labels: Some(labels.clone()),
-            ..ObjectMeta::default()
-        },
-        spec: Some(PersistentVolumeSpec {
-            storage_class_name: Some("manual".to_owned()),
-            capacity: Some(cap.clone()),
-            access_modes: Some(vec!["ReadWriteMany".to_owned()]),
-            host_path: Some(HostPathVolumeSource {
-                path: host_path.to_owned(),
-                ..HostPathVolumeSource::default()
-            }),
-            ..PersistentVolumeSpec::default()
-        }),
-        ..PersistentVolume::default()
-    };
-
-    pv
-}
-
-fn pvc_create(name: &str, namespace: &str, storage: u32, label_app: &str) -> PersistentVolumeClaim {
+) -> PersistentVolumeClaim {
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
     labels.insert("app".to_owned(), label_app.to_owned());
 
@@ -192,7 +35,7 @@ fn pvc_create(name: &str, namespace: &str, storage: u32, label_app: &str) -> Per
     cap.insert("storage".to_owned(), Quantity(size));
 
     // Definition of the persistent volume claim
-    let pvc: PersistentVolumeClaim = PersistentVolumeClaim {
+    PersistentVolumeClaim {
         metadata: ObjectMeta {
             name: Some(name.to_owned()),
             namespace: Some(namespace.to_owned()),
@@ -209,7 +52,37 @@ fn pvc_create(name: &str, namespace: &str, storage: u32, label_app: &str) -> Per
             ..PersistentVolumeClaimSpec::default()
         }),
         ..PersistentVolumeClaim::default()
-    };
+    }
+}
 
-    pvc
+/// Builds a persistent volume object for the manual local storage path.
+pub fn build_pv(name: &str, storage: u32, label_app: &str, host_path: &str) -> PersistentVolume {
+    let mut labels: BTreeMap<String, String> = BTreeMap::new();
+    labels.insert("app".to_owned(), label_app.to_owned());
+    labels.insert("type".to_owned(), "local".to_owned());
+
+    let mut size: String = storage.to_string().to_owned();
+    size.push_str("Gi");
+
+    let mut cap: BTreeMap<String, Quantity> = BTreeMap::new();
+    cap.insert("storage".to_owned(), Quantity(size));
+
+    PersistentVolume {
+        metadata: ObjectMeta {
+            name: Some(name.to_owned()),
+            labels: Some(labels),
+            ..ObjectMeta::default()
+        },
+        spec: Some(PersistentVolumeSpec {
+            storage_class_name: Some("manual".to_owned()),
+            capacity: Some(cap),
+            access_modes: Some(vec!["ReadWriteMany".to_owned()]),
+            host_path: Some(HostPathVolumeSource {
+                path: host_path.to_owned(),
+                ..HostPathVolumeSource::default()
+            }),
+            ..PersistentVolumeSpec::default()
+        }),
+        ..PersistentVolume::default()
+    }
 }

--- a/src/primary.rs
+++ b/src/primary.rs
@@ -17,81 +17,25 @@ use k8s_openapi::{
     },
     apimachinery::pkg::apis::meta::v1::LabelSelector,
 };
-use kube::{
-    Api, Client, Error,
-    api::{DeleteParams, ObjectMeta, PostParams},
-};
-use log::{info, trace};
+use kube::api::ObjectMeta;
 use std::collections::BTreeMap;
-use std::fs;
 
-/// Creates a primary deployment
+/// Builds a primary deployment object
 ///
 /// # Arguments
-/// - `client` - A Kubernetes client to create the deployment with
-/// - `name` - Name of the deployment to be created
-/// - `namespace` - Namespace to create the Kubernetes Deployment in
-///
-/// Note: It is assumed the resource does not already exists for simplicity. Returns an `Error` if it does
-pub async fn primary_deploy(
-    client: Client,
-    name: &str,
-    namespace: &str,
-) -> Result<Deployment, Error> {
-    // Definition of the deployment
-    let deployment: Deployment = primary_create(name, namespace);
-    trace!("d: {:?}", deployment);
-
-    // Create the deployment defined above
-    let deployment_api: Api<Deployment> = Api::namespaced(client, namespace);
-    match deployment_api
-        .create(&PostParams::default(), &deployment)
-        .await
-    {
-        Ok(o) => {
-            info!("Created Primary");
-            Ok(o)
-        }
-        Err(e) => Err(e),
-    }
-}
-
-/// Deletes an existing primary deployment.
-///
-/// # Arguments:
-/// - `client` - A Kubernetes client to delete the Deployment with
-/// - `name` - Name of the deployment to delete
-/// - `namespace` - Namespace the existing deployment resides in
-///
-/// Note: It is assumed the deployment exists for simplicity. Otherwise returns an Error.
-pub async fn primary_undeploy(client: Client, name: &str, namespace: &str) -> Result<(), Error> {
-    let api: Api<Deployment> = Api::namespaced(client, namespace);
-    match api.delete(name, &DeleteParams::default()).await {
-        Ok(_) => {
-            info!("Deleted Primary");
-        }
-
-        Err(e) => return Err(e),
-    }
-    Ok(())
-}
-
-/// Primary: Generate
-pub fn primary_generate() {
-    let data = serde_yaml::to_string(&primary_create("postgresql", "default"))
-        .expect("Can't serialize pgopr-primary.yaml");
-    fs::write("pgopr-primary.yaml", data).expect("Unable to write file: pgopr-primary.yaml");
-}
-
-fn primary_create(name: &str, namespace: &str) -> Deployment {
+/// - `name` - Name of the deployment
+/// - `namespace` - Namespace
+pub fn build(name: &str, namespace: &str) -> Deployment {
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
     labels.insert("app".to_owned(), name.to_owned());
+    labels.insert("role".to_owned(), "primary".to_owned());
 
     // Definition of the deployment
-    let deployment: Deployment = Deployment {
+    Deployment {
         metadata: ObjectMeta {
             name: Some(name.to_owned()),
             namespace: Some(namespace.to_owned()),
+            labels: Some(labels.clone()),
             ..ObjectMeta::default()
         },
         spec: Some(DeploymentSpec {
@@ -182,7 +126,5 @@ fn primary_create(name: &str, namespace: &str) -> Deployment {
             ..DeploymentSpec::default()
         }),
         ..Deployment::default()
-    };
-
-    deployment
+    }
 }

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -17,88 +17,27 @@ use k8s_openapi::{
     },
     apimachinery::pkg::apis::meta::v1::LabelSelector,
 };
-use kube::{
-    Api, Client, Error,
-    api::{DeleteParams, ObjectMeta, PostParams},
-};
-use log::{info, trace};
+use kube::api::ObjectMeta;
 use std::collections::BTreeMap;
-use std::fs;
 
-/// Creates a replica deployment
+/// Builds a replica deployment object
 ///
 /// # Arguments
-/// - `client` - A Kubernetes client to create the deployment with
-/// - `name` - Name of the deployment to be created
-/// - `namespace` - Namespace to create the Kubernetes Deployment in
-///
-/// Note: It is assumed the resource does not already exists for simplicity. Returns an `Error` if it does
-pub async fn replica_deploy(
-    client: Client,
-    name: &str,
-    primary_name: &str,
-    namespace: &str,
-    slot_name: &str,
-) -> Result<Deployment, Error> {
-    // Definition of the deployment
-    let deployment: Deployment = replica_create(name, primary_name, namespace, slot_name);
-    trace!("d: {:?}", deployment);
-
-    // Create the deployment defined above
-    let deployment_api: Api<Deployment> = Api::namespaced(client, namespace);
-    match deployment_api
-        .create(&PostParams::default(), &deployment)
-        .await
-    {
-        Ok(o) => {
-            info!("Created Replica");
-            Ok(o)
-        }
-        Err(e) => Err(e),
-    }
-}
-
-/// Deletes an existing replica deployment.
-///
-/// # Arguments:
-/// - `client` - A Kubernetes client to delete the Deployment with
-/// - `name` - Name of the deployment to delete
-/// - `namespace` - Namespace the existing deployment resides in
-///
-/// Note: It is assumed the deployment exists for simplicity. Otherwise returns an Error.
-pub async fn replica_undeploy(client: Client, name: &str, namespace: &str) -> Result<(), Error> {
-    let api: Api<Deployment> = Api::namespaced(client, namespace);
-    match api.delete(name, &DeleteParams::default()).await {
-        Ok(_) => {
-            info!("Deleted Replica");
-        }
-
-        Err(e) => return Err(e),
-    }
-    Ok(())
-}
-
-/// Replica: Generate
-pub fn replica_generate() {
-    let data = serde_yaml::to_string(&replica_create(
-        "postgresql-replica",
-        "postgresql",
-        "default",
-        "replica1",
-    ))
-    .expect("Can't serialize pgopr-replica.yaml");
-    fs::write("pgopr-replica.yaml", data).expect("Unable to write file: pgopr-replica.yaml");
-}
-
-fn replica_create(name: &str, primary_name: &str, namespace: &str, slot_name: &str) -> Deployment {
+/// - `name` - Name of the deployment
+/// - `primary_name` - Name of the primary deployment
+/// - `namespace` - Namespace
+/// - `slot_name` - The replication slot name
+pub fn build(name: &str, primary_name: &str, namespace: &str, slot_name: &str) -> Deployment {
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
     labels.insert("app".to_owned(), name.to_owned());
+    labels.insert("role".to_owned(), "replica".to_owned());
 
     // Definition of the deployment
-    let deployment: Deployment = Deployment {
+    Deployment {
         metadata: ObjectMeta {
             name: Some(name.to_owned()),
             namespace: Some(namespace.to_owned()),
+            labels: Some(labels.clone()),
             ..ObjectMeta::default()
         },
         spec: Some(DeploymentSpec {
@@ -164,7 +103,5 @@ fn replica_create(name: &str, primary_name: &str, namespace: &str, slot_name: &s
             ..DeploymentSpec::default()
         }),
         ..Deployment::default()
-    };
-
-    deployment
+    }
 }

--- a/src/services.rs
+++ b/src/services.rs
@@ -6,71 +6,19 @@
  *   OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
  */
 use k8s_openapi::api::core::v1::{Service, ServicePort, ServiceSpec};
-use kube::{
-    Api, Client, Error,
-    api::{DeleteParams, ObjectMeta, PostParams},
-};
-use log::{info, trace};
+use kube::api::ObjectMeta;
 use std::collections::BTreeMap;
-use std::fs;
 
-/// Creates a service
+/// Builds a service object
 ///
 /// # Arguments
-/// - `client` - The Kubernetes client
 /// - `name` - The name
 /// - `namespace` - The namespace
-///
-/// Note: It is assumed the service does not already exists for simplicity. Returns an `Error` if it does.
-pub async fn service_deploy(client: Client, name: &str, namespace: &str) -> Result<Service, Error> {
-    // Definition of the service
-    let s: Service = service_create(name, namespace);
-    trace!("{:#?}", s);
-
-    // Create the deployment defined above
-    let s_api: Api<Service> = Api::namespaced(client, namespace);
-    let result: Result<Service, Error> = s_api.create(&PostParams::default(), &s).await;
-
-    if result.is_ok() {
-        info!("Created Service");
-    }
-
-    result
-}
-
-/// Deletes a service
-///
-/// # Arguments:
-/// - `client` - The Kubernetes client
-/// - `name` - The name of the service
-/// - `namespace` - The namespace
-///
-/// Note: It is assumed the service exists for simplicity. Otherwise returns an Error.
-pub async fn service_undeploy(client: Client, name: &str, namespace: &str) -> Result<(), Error> {
-    let api: Api<Service> = Api::namespaced(client, namespace);
-    match api.delete(name, &DeleteParams::default()).await {
-        Ok(_) => {
-            info!("Deleted Service");
-        }
-
-        Err(e) => return Err(e),
-    }
-
-    Ok(())
-}
-
-/// Service: Generate
-pub fn service_generate() {
-    let data = serde_yaml::to_string(&service_create("postgresql", "default"))
-        .expect("Can't serialize pgopr-service.yaml");
-    fs::write("pgopr-service.yaml", data).expect("Unable to write file: pgopr-service.yaml");
-}
-
-fn service_create(name: &str, namespace: &str) -> Service {
+pub fn build(name: &str, namespace: &str) -> Service {
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
     labels.insert("app".to_owned(), name.to_owned());
 
-    let s: Service = Service {
+    Service {
         metadata: ObjectMeta {
             name: Some(name.to_owned()),
             namespace: Some(namespace.to_owned()),
@@ -87,7 +35,5 @@ fn service_create(name: &str, namespace: &str) -> Service {
             ..ServiceSpec::default()
         }),
         ..Service::default()
-    };
-
-    s
+    }
 }

--- a/test/check.sh
+++ b/test/check.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 readonly PGOPR_BIN="$PROJECT_ROOT/target/debug/pgopr"
+PGOPR_PID=""
 
 ## ================================
 ## Integration operations
@@ -39,6 +40,15 @@ build_operator() {
     cargo build
 }
 
+stop_operator() {
+    if [[ -n "${PGOPR_PID}" ]]; then
+        echo "Stopping the pgopr operator process..."
+        kill -TERM "$PGOPR_PID" 2>/dev/null || true
+        wait "$PGOPR_PID" 2>/dev/null || true
+        PGOPR_PID=""
+    fi
+}
+
 test_operator() {
     echo "Running basic tests for the operator (start/stop)..."
     
@@ -51,6 +61,7 @@ test_operator() {
     echo "Starting pgopr operator control loop in the background..."
     "$PGOPR_BIN" &
     PGOPR_PID=$!
+    trap stop_operator RETURN
 
     echo "Waiting for operator to initialize..."
     sleep 5
@@ -59,7 +70,7 @@ test_operator() {
     echo "Provisioning primary PostgreSQL instance..."
     "$PGOPR_BIN" provision primary
 
-    echo "Waiting for postgresql deployment to be ready..."
+    echo "Waiting for postgresql deployment to be created..."
     # pgopr creates a deployment named "postgresql"
     local count=0
     while ! kubectl get deployment postgresql >/dev/null 2>&1; do
@@ -71,11 +82,14 @@ test_operator() {
         sleep 5
         count=$((count+1))
     done
-    
-    # Once the deployment exists, we can use kubectl wait
-    kubectl wait --for=condition=Available deployment/postgresql --timeout=60s
-    
-    echo "PostgreSQL primary is running!"
+
+    echo "Checking reconciled PostgreSQL resources..."
+    kubectl get pv postgresql-pv-volume
+    kubectl get pvc postgresql-pv-claim
+    kubectl get service postgresql
+    kubectl get pgopr postgresql -o yaml
+
+    echo "PostgreSQL primary resources were reconciled."
     kubectl get pods
     kubectl get svc
 
@@ -96,14 +110,13 @@ test_operator() {
         delete_count=$((delete_count+1))
     done
 
-    echo "Stopping the pgopr operator process..."
-    kill -TERM "$PGOPR_PID" 2>/dev/null || true
-    wait "$PGOPR_PID" 2>/dev/null || true
+    stop_operator
 
     echo "Operations completed successfully."
 }
 
 cleanup_cluster() {
+    stop_operator
     echo "Cleaning up kind cluster..."
     kind delete cluster
 }


### PR DESCRIPTION
a new shared Cluster module for PostgreSQL star configuration topology and a ResourceManager for idempotent child resource writes. reconciler now derives PV, PVC, Deployment, and Service resources from PgOpr spec, updates status through the status subresource, and handles cleanup for managed resources.

refactore the CLI provision and retire commands to update the PgOpr resource instead of writing child resources directly. also refactor the primary, replica, services, and persistent modules into resource builders used by the reconciler.