### PR TITLE
[#23] adds release infrastructure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,195 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
+            gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --verify-tag
+          fi
+
+  build:
+    name: Build ${{ matrix.target }}
+    needs: create-release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+            package: true
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            archive: tar.gz
+            use_cross: true
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+            use_cross: true
+            package: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            archive: tar.gz
+            use_cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.use_cross
+        run: |
+          curl -L https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvzf -
+          sudo mv cargo-binstall /usr/local/bin/
+          cargo-binstall -y --force cross
+
+      - name: Build
+        shell: bash
+        run: |
+          if [ "${{ matrix.use_cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+
+      - name: Package (Unix Tarball)
+        if: matrix.archive == 'tar.gz'
+        shell: bash
+        run: |
+          BINARY=target/${{ matrix.target }}/release/pgopr
+          ARCHIVE=pgopr-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
+          cp README.md LICENSE $(dirname "$BINARY")/
+          tar -czf "$ARCHIVE" -C "$(dirname "$BINARY")" "$(basename "$BINARY")" README.md LICENSE
+          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
+
+      - name: Package (Windows Zip)
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          $binary = "target\${{ matrix.target }}\release\pgopr.exe"
+          $archive = "pgopr-${{ github.ref_name }}-${{ matrix.target }}.zip"
+          Compress-Archive -Path $binary, README.md, LICENSE -DestinationPath $archive
+          "ARCHIVE=$archive" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Build Native OS Packages (.deb & .rpm)
+        if: matrix.package == true
+        shell: bash
+        run: |
+          if ! command -v cargo-deb >/dev/null || ! command -v cargo-generate-rpm >/dev/null; then
+            if ! command -v cargo-binstall >/dev/null; then
+              curl -L https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz | tar -xvzf -
+              sudo mv cargo-binstall /usr/local/bin/
+            fi
+            cargo-binstall -y --force cargo-deb cargo-generate-rpm
+          fi
+          cargo deb --target ${{ matrix.target }} --no-build --no-strip --output pgopr-${{ github.ref_name }}-${{ matrix.target }}.deb
+          cargo generate-rpm --target ${{ matrix.target }} --output pgopr-${{ github.ref_name }}-${{ matrix.target }}.rpm
+
+      - name: Upload binaries to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.ref_name }}" "$ARCHIVE" --clobber
+          if [ "${{ matrix.package }}" = "true" ]; then
+            gh release upload "${{ github.ref_name }}" \
+              pgopr-${{ github.ref_name }}-${{ matrix.target }}.deb \
+              pgopr-${{ github.ref_name }}-${{ matrix.target }}.rpm \
+              --clobber
+          fi
+
+  manual:
+    name: Build manual
+    needs: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install pandoc and TeX Live
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pandoc \
+            texlive-xetex \
+            texlive-fonts-recommended \
+            texlive-fonts-extra \
+            texlive-plain-generic \
+            texlive-latex-extra \
+            lmodern
+
+      - name: Install eisvogel template
+        run: |
+          EISVOGEL_VERSION=3.4.0
+          mkdir -p ~/.local/share/pandoc/templates
+          curl -fsSLo /tmp/eisvogel.tar.gz \
+            "https://github.com/Wandmalfarbe/pandoc-latex-template/releases/download/v${EISVOGEL_VERSION}/Eisvogel.tar.gz"
+          tar -xzf /tmp/eisvogel.tar.gz -C ~/.local/share/pandoc/templates --strip-components=1
+
+      - name: Build manual
+        run: bash doc/build_manual.sh
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            target/doc/pgopr-en.pdf \
+            target/doc/pgopr-en.html \
+            --clobber
+
+  source:
+    name: Source bundle
+    needs: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Create source bundle
+        run: |
+          BUNDLE=pgopr-${{ github.ref_name }}-source.tar.gz
+          git archive --format=tar.gz --prefix=pgopr-${{ github.ref_name }}/ HEAD -o "$BUNDLE"
+          sha256sum "$BUNDLE" > "${BUNDLE}.sha256"
+          echo "BUNDLE=$BUNDLE" >> "$GITHUB_ENV"
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.ref_name }}" "$BUNDLE" "${BUNDLE}.sha256" --clobber

--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Bhawesh Panwar <panwarbhawesh1112@gmail.com>
 Sakshii-27 <sakshiaggarwal2706@gmail.com>
 Frank Heikens <frank@elevarq.com>
 Amr Shams     <amr.shams2015.as@gmail.com>
+Sarthak Aneja <sarthakaneja260@gmail.com>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,28 @@ serde_json = { version = "1.0" }
 serde_yaml = { version = "0.9" }
 thiserror = { version = "2.0" }
 toml = { version = "0.9" }
+
+[package.metadata.deb]
+maintainer = "Jesper Pedersen <jesperpedersen.db@gmail.com>"
+copyright = "2026 pgopr developers"
+license-file = ["LICENSE", "0"]
+depends = "libc6"
+section = "database"
+priority = "optional"
+assets = [
+    ["target/release/pgopr", "usr/bin/pgopr", "755"],
+    ["README.md", "usr/share/doc/pgopr/README.md", "644"],
+    ["LICENSE", "usr/share/doc/pgopr/LICENSE", "644"],
+]
+
+[package.metadata.generate-rpm]
+assets = [
+    { source = "target/release/pgopr", dest = "/usr/bin/pgopr", mode = "0755" },
+    { source = "README.md", dest = "/usr/share/doc/pgopr/README.md", mode = "0644" },
+    { source = "LICENSE", dest = "/usr/share/doc/pgopr/LICENSE", mode = "0644" }
+]
+auto-req = "no"
+
+[profile.release]
+strip = true
+

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -12,6 +12,7 @@ Cristian Guarino <cristian.guarino.j@gmail.com>
 Nick Boyadjian <nboyadjian95@gmail.com>
 Bhawesh Panwar <panwarbhawesh1112@gmail.com>
 Sakshii-27 <sakshiaggarwal2706@gmail.com>
+Sarthak Aneja <sarthakaneja260@gmail.com>
 ```
 
 ## Committers


### PR DESCRIPTION
This PR adds release infrastructure to automate binary building and packaging

1. Automated Releases Workflow: Created a tag triggered release pipeline modeled after `orangu` that builds, packages, and uploads assets for 7 targets across Linux, macOS, and Windows.
2. Native OS Packaging: Appended custom configurations to `Cargo.toml` to map files and compile static stripped release binaries for clean `.deb` and `.rpm` generation.
3. Manual and Source Bundling: Added workflow jobs to build HTML/PDF user manuals and package source code archives with SHA256 checksums

resolves [#23]
